### PR TITLE
style(globals.css): adjust grid template columns width

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -11,7 +11,7 @@
             theme('colors.secondary') 100%
         );
         --foreground: #2B2A28;
-        --grid-template-columns: repeat(auto-fill, minmax(min(var(--col-width, 270px), 100%), 1fr));
+        --grid-template-columns: repeat(auto-fill, minmax(min(var(--col-width, 320px), 100%), 1fr));
         --product-gradient: linear-gradient(
             180deg,
             rgba(255, 255, 255, 0) 0%,


### PR DESCRIPTION
The default column width in the grid template was increased from 270px to 320px to improve the layout and spacing of grid items, ensuring better visual balance and usability.