### PR TITLE
refactor(product): limit product query to 5000 items and add logging

### DIFF
--- a/sanity/lib/product/getAllProductsFromSanity.ts
+++ b/sanity/lib/product/getAllProductsFromSanity.ts
@@ -12,11 +12,13 @@ export async function getAllProductsFromSanity(): Promise<any[]> {
      * The `*[_type == "product"]` syntax tells Sanity to fetch all documents of type `product`.
      * The `| order(name asc)` syntax tells Sanity to order the results by the `name` field in ascending order.
      */
-    const ALL_PRODUCTS_QUERY = defineQuery(`*[_type == "product"] | order(name asc)`);
+    const ALL_PRODUCTS_QUERY = defineQuery(`*[_type == "product"][0...5000] | order(name asc)`);
 
     try {
         // Fetch the products from Sanity using the client.fetch() method
         const products = await getSanityDocuments(ALL_PRODUCTS_QUERY);
+
+        console.log("Products", products);
 
         // Return the list of products or an empty array if not available
         return products ?? [];


### PR DESCRIPTION
Limit the product query to fetch only the first 5000 items to improve performance and avoid potential memory issues. Additionally, add logging to help debug the fetched products.