### PR TITLE
refactor: improve product data handling and caching

### DIFF
--- a/app/(app)/(store)/products/page.tsx
+++ b/app/(app)/(store)/products/page.tsx
@@ -8,6 +8,8 @@ import Section from '@/components/layout/Section';
 import ProductsView from '@/components/shared/product/ProductsView';
 import { getAllProductCategories } from '@/sanity/lib/product/getAllProductCategories';
 import { getAllProductsFromSanity } from '@/sanity/lib/product/getAllProductsFromSanity';
+import { getProductsByLimit } from '@/lib/actions/product.actions';
+import { extractProductData } from '@/lib/extract-product-data';
 
 export default async function ProductsPage(
     {
@@ -23,8 +25,10 @@ export default async function ProductsPage(
     const [categories, breadcrumbs, products] = await Promise.all([
         getAllProductCategories(),
         getSanityDocuments(NAVIGATION_QUERY),
-        getAllProductsFromSanity()
+        // getAllProductsFromSanity(),
+        getProductsByLimit(5000),
     ]);
+    const productListByLimit = products.map((item) => {return extractProductData({...item, _id: 'id'} as any);})
 
     return (
         <>
@@ -58,7 +62,7 @@ export default async function ProductsPage(
                 </div>
             </section>
             <Section id="products" innerClassname='pt-6 md:pt-6'>
-                <ProductsView products={products} categories={categories} />
+                <ProductsView products={productListByLimit} categories={categories} />
             </Section>
         </>
     );

--- a/lib/extract-product-data.ts
+++ b/lib/extract-product-data.ts
@@ -3,7 +3,7 @@ import { getPrice } from '@/lib/getPrice';
 
 // Product helper functions
 export const extractProductData = (product: Product): ProductData => ({
-    _id: product.id[0]._,
+    _id: product?.id[0]?._ || '',
     id: product.id[0]._,
     name: product.product[0]._,
     price: parseFloat(getPrice(product.price[0], 1.1)),

--- a/sanity/lib/fetch-sanity-data.ts
+++ b/sanity/lib/fetch-sanity-data.ts
@@ -5,7 +5,7 @@ import { SERVICES_QUERY } from '@/sanity/lib/queries';
 
 // Options object for Next.js data fetching
 // revalidate: 0 means the data will be fetched on every request (no caching)
-const options = { next: { revalidate: 0 } };
+const options = { next: { revalidate: 30 } };
 export async function getSanityDocuments(QUERY = SERVICES_QUERY, params={}) {
   try {
     return await client.fetch<SanityDocument[]>(QUERY, params, options);

--- a/sanity/lib/product/getAllProductsFromSanity.ts
+++ b/sanity/lib/product/getAllProductsFromSanity.ts
@@ -18,8 +18,6 @@ export async function getAllProductsFromSanity(): Promise<any[]> {
         // Fetch the products from Sanity using the client.fetch() method
         const products = await getSanityDocuments(ALL_PRODUCTS_QUERY);
 
-        console.log("Products", products);
-
         // Return the list of products or an empty array if not available
         return products ?? [];
     } catch (error) {


### PR DESCRIPTION
- Add optional chaining and fallback for product ID in extractProductData to prevent errors
- Update revalidate interval to 30 seconds for better caching in getSanityDocuments
- Remove debug console.log in getAllProductsFromSanity
- Replace getAllProductsFromSanity with getProductsByLimit for better performance and scalability
- Map product data using extractProductData for consistent product structure