### PR TITLE
feat(product): add tooltip support to product color selection

### DIFF
--- a/components/shared/product/ProductColors.tsx
+++ b/components/shared/product/ProductColors.tsx
@@ -6,7 +6,7 @@ import { filterItemsByColor } from './lib';
 const ColorListItem = ({ item }: { item: ColorItemProps }) => (
     <li key={item.id}>
         <NextImage
-            alt={"color"}
+            alt={item.color || "color"}
             src={item.cover}
             width={36}
             height={36}
@@ -38,7 +38,7 @@ const computedItems = (list: ColorItemProps[]) => filterItemsByColor(list);
 
 const ProductColors = ({ list }: { list: ColorItemProps[] }) => {
     if (!Array.isArray(list) || list.length === 0) return null;
-    
+
     return (
         <ProductColorsWrapper>
             <ColorList items={computedItems(list)} />

--- a/components/shared/product/ProductDetails.tsx
+++ b/components/shared/product/ProductDetails.tsx
@@ -6,6 +6,12 @@ import clsx from 'clsx';
 import NextImage from 'next/image';
 import { useEffect, useState } from 'react';
 import { ColorList, ColorListItem, computedItems } from './ProductColors';
+import { Tooltip } from '@heroui/tooltip';
+
+/**
+ * A component to display a product thumbnail.
+ *
+ * @param {Object} props - Component props
 
 /**
  * A component to display product details.
@@ -35,30 +41,36 @@ export const ProductDetails: React.FC<{
                 Array.isArray(items) && items.length > 0 && (
                     <fieldset aria-label="Choose a color">
                         <RadioGroup
-                            label="Цвет"
+                            label="Варианты"
                             orientation="horizontal"
                             defaultValue={items[0].color}
                             classNames={{
-                                label: "text-foreground font-semibold text-sm"
+                                label: "text-foreground font-semibold text-sm",
+                                base: "list-none"
                             }}
                         >
                             {
                                 (Array.isArray(items) && items.length > 0) && (
                                     computedItems(items).map((color) => (
-                                        <Radio
-                                            key={color.id}
-                                            value={color.color}
-                                            aria-label={color.color}
-                                            name={color.color}
-                                            classNames={{
-                                                base: "data-[disabled=true]:cursor-not-allowed data-[selected=true]:border-primary data-[selected=true]:ring-2 ring-offset-2 ring-primary data-[selected=true]:bg-primary data-[selected=true]:text-white border-gray-300 border-1 pointer-events-auto",
-                                                control: clsx("hidden"),
-                                                hiddenInput: "disabled:cursor-not-allowed",
-                                                wrapper: "hidden"
-                                            }}
-                                        >
-                                            <ColorListItem item={color} />
-                                        </Radio>
+                                        <Tooltip content={color.color} key={color.id} radius='sm'>
+                                            <Radio
+                                                value={color.color}
+                                                aria-label={color.color}
+                                                name={color.color}
+                                                title={color.color}
+                                                classNames={{
+                                                    base: "data-[disabled=true]:cursor-not-allowed data-[selected=true]:border-primary data-[selected=true]:ring-2 ring-offset-2 ring-primary list-none pointer-events-auto",
+                                                    control: clsx("hidden"),
+                                                    hiddenInput: "disabled:cursor-not-allowed",
+                                                    wrapper: "hidden"
+                                                }}
+                                            >
+                                                <ColorListItem item={color} />
+                                            </Radio>
+                                        </Tooltip>
+                                        // <Link key={color.id} href={`/product/${color.id}`}>
+
+                                        // </Link>
                                     ))
                                 )
                             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
     "@heroui/system": "2.4.11",
     "@heroui/table": "^2.2.15",
     "@heroui/theme": "2.4.11",
+    "@heroui/tooltip": "^2.2.16",
     "@react-aria/ssr": "3.9.7",
     "@react-aria/visually-hidden": "3.8.18",
     "@react-stately/data": "^3.12.1",
@@ -4197,6 +4198,88 @@
     "react-dom": ">=18 || >=19.0.0-rc.0"
    }
   },
+  "node_modules/@heroui/snippet/node_modules/@heroui/tooltip": {
+   "version": "2.2.13",
+   "resolved": "https://registry.npmjs.org/@heroui/tooltip/-/tooltip-2.2.13.tgz",
+   "integrity": "sha512-pYfWuhFbOLevr/YnwtT8rLlNbsiOb3WwYo9378ZByHQFCNS0Fd+qPVU+9i7Z/+am3XLoQxgQ5r7OTlMnmCjVmg==",
+   "license": "MIT",
+   "dependencies": {
+    "@heroui/aria-utils": "2.2.13",
+    "@heroui/dom-animation": "2.1.6",
+    "@heroui/framer-utils": "2.1.12",
+    "@heroui/react-utils": "2.1.8",
+    "@heroui/shared-utils": "2.1.7",
+    "@heroui/use-safe-layout-effect": "2.1.6",
+    "@react-aria/interactions": "3.24.0",
+    "@react-aria/overlays": "3.26.0",
+    "@react-aria/tooltip": "3.8.0",
+    "@react-aria/utils": "3.28.0",
+    "@react-stately/tooltip": "3.5.2",
+    "@react-types/overlays": "3.8.13",
+    "@react-types/tooltip": "3.4.15"
+   },
+   "peerDependencies": {
+    "@heroui/system": ">=2.4.7",
+    "@heroui/theme": ">=2.4.6",
+    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+    "react": ">=18 || >=19.0.0-rc.0",
+    "react-dom": ">=18 || >=19.0.0-rc.0"
+   }
+  },
+  "node_modules/@heroui/snippet/node_modules/@react-aria/tooltip": {
+   "version": "3.8.0",
+   "resolved": "https://registry.npmjs.org/@react-aria/tooltip/-/tooltip-3.8.0.tgz",
+   "integrity": "sha512-Tal09bWgursZ3v1qUuB/0z4Cz+jcDIfe8G5TECMtr0vbfYh2u7RIjBNZnsRcxZ2syXDxhHrPNeh8mrp4vKCAKg==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@react-aria/interactions": "^3.24.0",
+    "@react-aria/utils": "^3.28.0",
+    "@react-stately/tooltip": "^3.5.2",
+    "@react-types/shared": "^3.28.0",
+    "@react-types/tooltip": "^3.4.15",
+    "@swc/helpers": "^0.5.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@heroui/snippet/node_modules/@react-stately/tooltip": {
+   "version": "3.5.2",
+   "resolved": "https://registry.npmjs.org/@react-stately/tooltip/-/tooltip-3.5.2.tgz",
+   "integrity": "sha512-z81kwZWnnf2SE5/rHMrejH5uQu3dXUjrhIa2AGT038DNOmRyS9TkFBywPCiiE7tHpUg/rxZrPxx01JFGvOkmgg==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@react-stately/overlays": "^3.6.14",
+    "@react-types/tooltip": "^3.4.15",
+    "@swc/helpers": "^0.5.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@heroui/snippet/node_modules/@react-types/shared": {
+   "version": "3.29.0",
+   "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.0.tgz",
+   "integrity": "sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==",
+   "license": "Apache-2.0",
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@heroui/snippet/node_modules/@react-types/tooltip": {
+   "version": "3.4.15",
+   "resolved": "https://registry.npmjs.org/@react-types/tooltip/-/tooltip-3.4.15.tgz",
+   "integrity": "sha512-qiYwQLiEwYqrt/m8iQA8abl9k/9LrbtMNoEevL4jN4H0I5NrG55E78GYTkSzBBYmhBO4KnPVT0SfGM1tYaQx/A==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@react-types/overlays": "^3.8.13",
+    "@react-types/shared": "^3.28.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
   "node_modules/@heroui/spacer": {
    "version": "2.2.12",
    "resolved": "https://registry.npmjs.org/@heroui/spacer/-/spacer-2.2.12.tgz",
@@ -4585,24 +4668,24 @@
    }
   },
   "node_modules/@heroui/tooltip": {
-   "version": "2.2.13",
-   "resolved": "https://registry.npmjs.org/@heroui/tooltip/-/tooltip-2.2.13.tgz",
-   "integrity": "sha512-pYfWuhFbOLevr/YnwtT8rLlNbsiOb3WwYo9378ZByHQFCNS0Fd+qPVU+9i7Z/+am3XLoQxgQ5r7OTlMnmCjVmg==",
+   "version": "2.2.16",
+   "resolved": "https://registry.npmjs.org/@heroui/tooltip/-/tooltip-2.2.16.tgz",
+   "integrity": "sha512-pdQZTW04P+Ol6fr6ZfCHDVT+BRksx0n2kGJskMpEYKS0Q4Dk1AKmbVxfHYrT7yOQFQTTmTFJzkbbFMLFgg/Wrg==",
    "license": "MIT",
    "dependencies": {
-    "@heroui/aria-utils": "2.2.13",
-    "@heroui/dom-animation": "2.1.6",
-    "@heroui/framer-utils": "2.1.12",
-    "@heroui/react-utils": "2.1.8",
-    "@heroui/shared-utils": "2.1.7",
-    "@heroui/use-safe-layout-effect": "2.1.6",
-    "@react-aria/interactions": "3.24.0",
-    "@react-aria/overlays": "3.26.0",
-    "@react-aria/tooltip": "3.8.0",
-    "@react-aria/utils": "3.28.0",
-    "@react-stately/tooltip": "3.5.2",
-    "@react-types/overlays": "3.8.13",
-    "@react-types/tooltip": "3.4.15"
+    "@heroui/aria-utils": "2.2.16",
+    "@heroui/dom-animation": "2.1.8",
+    "@heroui/framer-utils": "2.1.15",
+    "@heroui/react-utils": "2.1.10",
+    "@heroui/shared-utils": "2.1.9",
+    "@heroui/use-safe-layout-effect": "2.1.7",
+    "@react-aria/interactions": "3.25.0",
+    "@react-aria/overlays": "3.27.0",
+    "@react-aria/tooltip": "3.8.2",
+    "@react-aria/utils": "3.28.2",
+    "@react-stately/tooltip": "3.5.3",
+    "@react-types/overlays": "3.8.14",
+    "@react-types/tooltip": "3.4.16"
    },
    "peerDependencies": {
     "@heroui/system": ">=2.4.7",
@@ -4610,6 +4693,385 @@
     "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
     "react": ">=18 || >=19.0.0-rc.0",
     "react-dom": ">=18 || >=19.0.0-rc.0"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@heroui/aria-utils": {
+   "version": "2.2.16",
+   "resolved": "https://registry.npmjs.org/@heroui/aria-utils/-/aria-utils-2.2.16.tgz",
+   "integrity": "sha512-d4MuOSpn95RgxJloLc9mDfo162Z0/YtErr6CgXbIWNQfZL8AfBxUMCuhYS1KCUwBV6usitMf2XIW4zGEGtMkXA==",
+   "license": "MIT",
+   "dependencies": {
+    "@heroui/react-rsc-utils": "2.1.7",
+    "@heroui/shared-utils": "2.1.9",
+    "@heroui/system": "2.4.15",
+    "@react-aria/utils": "3.28.2",
+    "@react-stately/collections": "3.12.3",
+    "@react-stately/overlays": "3.6.15",
+    "@react-types/overlays": "3.8.14",
+    "@react-types/shared": "3.29.0"
+   },
+   "peerDependencies": {
+    "react": ">=18 || >=19.0.0-rc.0",
+    "react-dom": ">=18 || >=19.0.0-rc.0"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@heroui/aria-utils/node_modules/@heroui/system": {
+   "version": "2.4.15",
+   "resolved": "https://registry.npmjs.org/@heroui/system/-/system-2.4.15.tgz",
+   "integrity": "sha512-+QUHscs2RTk5yOFEQXNlQa478P7PTD02ZGP/RTNCviR4E9ZTUifdjfsKA7D4L79S7L8Mkvbz5E2Ruz2ZF0R/IA==",
+   "license": "MIT",
+   "dependencies": {
+    "@heroui/react-utils": "2.1.10",
+    "@heroui/system-rsc": "2.3.13",
+    "@internationalized/date": "3.8.0",
+    "@react-aria/i18n": "3.12.8",
+    "@react-aria/overlays": "3.27.0",
+    "@react-aria/utils": "3.28.2",
+    "@react-stately/utils": "3.10.6",
+    "@react-types/datepicker": "3.12.0"
+   },
+   "peerDependencies": {
+    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+    "react": ">=18 || >=19.0.0-rc.0",
+    "react-dom": ">=18 || >=19.0.0-rc.0"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@heroui/dom-animation": {
+   "version": "2.1.8",
+   "resolved": "https://registry.npmjs.org/@heroui/dom-animation/-/dom-animation-2.1.8.tgz",
+   "integrity": "sha512-88PwAmkF+lodZisF1OB3CuwNs+1sTB5eAfGvXZGUCO/rNZvGIL4KxmxuDM2odb0MJYklMU39+aqCEg/U+x2tEA==",
+   "license": "MIT",
+   "peerDependencies": {
+    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@heroui/framer-utils": {
+   "version": "2.1.15",
+   "resolved": "https://registry.npmjs.org/@heroui/framer-utils/-/framer-utils-2.1.15.tgz",
+   "integrity": "sha512-SH6hIz0OrhJrx284Gnp1EpCnNL8Dkt3XFmtHogNsE9ggRwMLy1xKIqyVni0V4ZmUe1DNGKAW9ywHV3onp3pFfg==",
+   "license": "MIT",
+   "dependencies": {
+    "@heroui/shared-utils": "2.1.9",
+    "@heroui/system": "2.4.15",
+    "@heroui/use-measure": "2.1.7"
+   },
+   "peerDependencies": {
+    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+    "react": ">=18 || >=19.0.0-rc.0",
+    "react-dom": ">=18 || >=19.0.0-rc.0"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@heroui/framer-utils/node_modules/@heroui/system": {
+   "version": "2.4.15",
+   "resolved": "https://registry.npmjs.org/@heroui/system/-/system-2.4.15.tgz",
+   "integrity": "sha512-+QUHscs2RTk5yOFEQXNlQa478P7PTD02ZGP/RTNCviR4E9ZTUifdjfsKA7D4L79S7L8Mkvbz5E2Ruz2ZF0R/IA==",
+   "license": "MIT",
+   "dependencies": {
+    "@heroui/react-utils": "2.1.10",
+    "@heroui/system-rsc": "2.3.13",
+    "@internationalized/date": "3.8.0",
+    "@react-aria/i18n": "3.12.8",
+    "@react-aria/overlays": "3.27.0",
+    "@react-aria/utils": "3.28.2",
+    "@react-stately/utils": "3.10.6",
+    "@react-types/datepicker": "3.12.0"
+   },
+   "peerDependencies": {
+    "framer-motion": ">=11.5.6 || >=12.0.0-alpha.1",
+    "react": ">=18 || >=19.0.0-rc.0",
+    "react-dom": ">=18 || >=19.0.0-rc.0"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@heroui/react-rsc-utils": {
+   "version": "2.1.7",
+   "resolved": "https://registry.npmjs.org/@heroui/react-rsc-utils/-/react-rsc-utils-2.1.7.tgz",
+   "integrity": "sha512-NYKKOLs+KHA8v0+PxkkhVXxTD0WNvC4QMlMjUVshzpWhjnOHIrtXjAtqO6XezWmiKNKY76FAjnMZP+Be5+j5uw==",
+   "license": "MIT",
+   "peerDependencies": {
+    "react": ">=18 || >=19.0.0-rc.0"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@heroui/react-utils": {
+   "version": "2.1.10",
+   "resolved": "https://registry.npmjs.org/@heroui/react-utils/-/react-utils-2.1.10.tgz",
+   "integrity": "sha512-Wj3BSQnNFrDzDnN44vYEwTScMpdbylbZwO8UxIY02AoQCBD5QW7Wf0r2FVlrsrjPjMOVeogwlVvCBYvZz5hHnQ==",
+   "license": "MIT",
+   "dependencies": {
+    "@heroui/react-rsc-utils": "2.1.7",
+    "@heroui/shared-utils": "2.1.9"
+   },
+   "peerDependencies": {
+    "react": ">=18 || >=19.0.0-rc.0"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@heroui/shared-utils": {
+   "version": "2.1.9",
+   "resolved": "https://registry.npmjs.org/@heroui/shared-utils/-/shared-utils-2.1.9.tgz",
+   "integrity": "sha512-mM/Ep914cYMbw3T/b6+6loYhuNfzDaph76mzw/oIS05gw1Dhp9luCziSiIhqDGgzYck2d74oWTZlahyCsxf47w==",
+   "hasInstallScript": true,
+   "license": "MIT"
+  },
+  "node_modules/@heroui/tooltip/node_modules/@heroui/system-rsc": {
+   "version": "2.3.13",
+   "resolved": "https://registry.npmjs.org/@heroui/system-rsc/-/system-rsc-2.3.13.tgz",
+   "integrity": "sha512-zLBrDKCoM4o039t3JdfYZAOlHmn4RzI6gxU+Tw8XJIfvUzpGSvR2seY2XJBbKOonmTpILlnw16ZvHF+KG+nN0w==",
+   "license": "MIT",
+   "dependencies": {
+    "@react-types/shared": "3.29.0",
+    "clsx": "^1.2.1"
+   },
+   "peerDependencies": {
+    "@heroui/theme": ">=2.4.6",
+    "react": ">=18 || >=19.0.0-rc.0"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@heroui/system-rsc/node_modules/clsx": {
+   "version": "1.2.1",
+   "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+   "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+   "license": "MIT",
+   "engines": {
+    "node": ">=6"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@heroui/use-measure": {
+   "version": "2.1.7",
+   "resolved": "https://registry.npmjs.org/@heroui/use-measure/-/use-measure-2.1.7.tgz",
+   "integrity": "sha512-H586tr/bOH08MAufeiT35E1QmF8SPQy5Ghmat1Bb+vh/6KZ5S0K0o95BE2to7sXE9UCJWa7nDFuizXAGbveSiA==",
+   "license": "MIT",
+   "peerDependencies": {
+    "react": ">=18 || >=19.0.0-rc.0"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@heroui/use-safe-layout-effect": {
+   "version": "2.1.7",
+   "resolved": "https://registry.npmjs.org/@heroui/use-safe-layout-effect/-/use-safe-layout-effect-2.1.7.tgz",
+   "integrity": "sha512-ZiMc+nVjcE5aArC4PEmnLHSJj0WgAXq3udr7FZaosP/jrRdn5VPcfF9z9cIGNJD6MkZp+YP0XGslrIFKZww0Hw==",
+   "license": "MIT",
+   "peerDependencies": {
+    "react": ">=18 || >=19.0.0-rc.0"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@internationalized/date": {
+   "version": "3.8.0",
+   "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.0.tgz",
+   "integrity": "sha512-J51AJ0fEL68hE4CwGPa6E0PO6JDaVLd8aln48xFCSy7CZkZc96dGEGmLs2OEEbBxcsVZtfrqkXJwI2/MSG8yKw==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@swc/helpers": "^0.5.0"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@react-aria/focus": {
+   "version": "3.20.2",
+   "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.20.2.tgz",
+   "integrity": "sha512-Q3rouk/rzoF/3TuH6FzoAIKrl+kzZi9LHmr8S5EqLAOyP9TXIKG34x2j42dZsAhrw7TbF9gA8tBKwnCNH4ZV+Q==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@react-aria/interactions": "^3.25.0",
+    "@react-aria/utils": "^3.28.2",
+    "@react-types/shared": "^3.29.0",
+    "@swc/helpers": "^0.5.0",
+    "clsx": "^2.0.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@react-aria/i18n": {
+   "version": "3.12.8",
+   "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.12.8.tgz",
+   "integrity": "sha512-V/Nau9WuwTwxfFffQL4URyKyY2HhRlu9zmzkF2Hw/j5KmEQemD+9jfaLueG2CJu85lYL06JrZXUdnhZgKnqMkA==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@internationalized/date": "^3.8.0",
+    "@internationalized/message": "^3.1.7",
+    "@internationalized/number": "^3.6.1",
+    "@internationalized/string": "^3.2.6",
+    "@react-aria/ssr": "^3.9.8",
+    "@react-aria/utils": "^3.28.2",
+    "@react-types/shared": "^3.29.0",
+    "@swc/helpers": "^0.5.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@react-aria/interactions": {
+   "version": "3.25.0",
+   "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.25.0.tgz",
+   "integrity": "sha512-GgIsDLlO8rDU/nFn6DfsbP9rfnzhm8QFjZkB9K9+r+MTSCn7bMntiWQgMM+5O6BiA8d7C7x4zuN4bZtc0RBdXQ==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@react-aria/ssr": "^3.9.8",
+    "@react-aria/utils": "^3.28.2",
+    "@react-stately/flags": "^3.1.1",
+    "@react-types/shared": "^3.29.0",
+    "@swc/helpers": "^0.5.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@react-aria/overlays": {
+   "version": "3.27.0",
+   "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.27.0.tgz",
+   "integrity": "sha512-2vZVgL7FrloN5Rh8sAhadGADJbuWg69DdSJB3fd2/h5VvcEhnIfNPu9Ma5XmdkApDoTboIEsKZ4QLYwRl98w6w==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@react-aria/focus": "^3.20.2",
+    "@react-aria/i18n": "^3.12.8",
+    "@react-aria/interactions": "^3.25.0",
+    "@react-aria/ssr": "^3.9.8",
+    "@react-aria/utils": "^3.28.2",
+    "@react-aria/visually-hidden": "^3.8.22",
+    "@react-stately/overlays": "^3.6.15",
+    "@react-types/button": "^3.12.0",
+    "@react-types/overlays": "^3.8.14",
+    "@react-types/shared": "^3.29.0",
+    "@swc/helpers": "^0.5.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@react-aria/ssr": {
+   "version": "3.9.8",
+   "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.8.tgz",
+   "integrity": "sha512-lQDE/c9uTfBSDOjaZUJS8xP2jCKVk4zjQeIlCH90xaLhHDgbpCdns3xvFpJJujfj3nI4Ll9K7A+ONUBDCASOuw==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@swc/helpers": "^0.5.0"
+   },
+   "engines": {
+    "node": ">= 12"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@react-aria/utils": {
+   "version": "3.28.2",
+   "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.28.2.tgz",
+   "integrity": "sha512-J8CcLbvnQgiBn54eeEvQQbIOfBF3A1QizxMw9P4cl9MkeR03ug7RnjTIdJY/n2p7t59kLeAB3tqiczhcj+Oi5w==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@react-aria/ssr": "^3.9.8",
+    "@react-stately/flags": "^3.1.1",
+    "@react-stately/utils": "^3.10.6",
+    "@react-types/shared": "^3.29.0",
+    "@swc/helpers": "^0.5.0",
+    "clsx": "^2.0.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@react-aria/visually-hidden": {
+   "version": "3.8.22",
+   "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.22.tgz",
+   "integrity": "sha512-EO3R8YTKZ7HkLl9k1Y2uBKYBgpJagth4/4W7mfpJZE24A3fQnCP8zx1sweXiAm0mirR4J6tNaK7Ia8ssP5TpOw==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@react-aria/interactions": "^3.25.0",
+    "@react-aria/utils": "^3.28.2",
+    "@react-types/shared": "^3.29.0",
+    "@swc/helpers": "^0.5.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@react-stately/collections": {
+   "version": "3.12.3",
+   "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.12.3.tgz",
+   "integrity": "sha512-QfSBME2QWDjUw/RmmUjrYl/j1iCYcYCIDsgZda1OeRtt63R11k0aqmmwrDRwCsA+Sv+D5QgkOp4KK+CokTzoVQ==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@react-types/shared": "^3.29.0",
+    "@swc/helpers": "^0.5.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@react-stately/overlays": {
+   "version": "3.6.15",
+   "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.15.tgz",
+   "integrity": "sha512-LBaGpXuI+SSd5HSGzyGJA0Gy09V2tl2G/r0lllTYqwt0RDZR6p7IrhdGVXZm6vI0oWEnih7yLC32krkVQrffgQ==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@react-stately/utils": "^3.10.6",
+    "@react-types/overlays": "^3.8.14",
+    "@swc/helpers": "^0.5.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@react-stately/utils": {
+   "version": "3.10.6",
+   "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.6.tgz",
+   "integrity": "sha512-O76ip4InfTTzAJrg8OaZxKU4vvjMDOpfA/PGNOytiXwBbkct2ZeZwaimJ8Bt9W1bj5VsZ81/o/tW4BacbdDOMA==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@swc/helpers": "^0.5.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@react-types/button": {
+   "version": "3.12.0",
+   "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.12.0.tgz",
+   "integrity": "sha512-YrASNa+RqGQpzJcxNAahzNuTYVID1OE6HCorrEOXIyGS3EGogHsQmFs9OyThXnGHq6q4rLlA806/jWbP9uZdxA==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@react-types/shared": "^3.29.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@react-types/datepicker": {
+   "version": "3.12.0",
+   "resolved": "https://registry.npmjs.org/@react-types/datepicker/-/datepicker-3.12.0.tgz",
+   "integrity": "sha512-dw/xflOdQPQ3uEABaBrZRTvjsMRu5/VZjRx9ygc64sX2N7HKIt+foMPXKJ+1jhtki2p4gigNVjcnJndJHoj9SA==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@internationalized/date": "^3.8.0",
+    "@react-types/calendar": "^3.7.0",
+    "@react-types/overlays": "^3.8.14",
+    "@react-types/shared": "^3.29.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@react-types/overlays": {
+   "version": "3.8.14",
+   "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.14.tgz",
+   "integrity": "sha512-XJS67KHYhdMvPNHXNGdmc85gE+29QT5TwC58V4kxxHVtQh9fYzEEPzIV8K84XWSz04rRGe3fjDgRNbcqBektWQ==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@react-types/shared": "^3.29.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@heroui/tooltip/node_modules/@react-types/shared": {
+   "version": "3.29.0",
+   "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.0.tgz",
+   "integrity": "sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==",
+   "license": "Apache-2.0",
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
    }
   },
   "node_modules/@heroui/use-aria-accordion": {
@@ -5682,9 +6144,9 @@
    }
   },
   "node_modules/@internationalized/message": {
-   "version": "3.1.6",
-   "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.6.tgz",
-   "integrity": "sha512-JxbK3iAcTIeNr1p0WIFg/wQJjIzJt9l/2KNY/48vXV7GRGZSv3zMxJsce008fZclk2cDC8y0Ig3odceHO7EfNQ==",
+   "version": "3.1.7",
+   "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.7.tgz",
+   "integrity": "sha512-gLQlhEW4iO7DEFPf/U7IrIdA3UyLGS0opeqouaFwlMObLUzwexRjbygONHDVbC9G9oFLXsLyGKYkJwqXw/QADg==",
    "license": "Apache-2.0",
    "dependencies": {
     "@swc/helpers": "^0.5.0",
@@ -5692,18 +6154,18 @@
    }
   },
   "node_modules/@internationalized/number": {
-   "version": "3.6.0",
-   "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.0.tgz",
-   "integrity": "sha512-PtrRcJVy7nw++wn4W2OuePQQfTqDzfusSuY1QTtui4wa7r+rGVtR75pO8CyKvHvzyQYi3Q1uO5sY0AsB4e65Bw==",
+   "version": "3.6.1",
+   "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.1.tgz",
+   "integrity": "sha512-UVsb4bCwbL944E0SX50CHFtWEeZ2uB5VozZ5yDXJdq6iPZsZO5p+bjVMZh2GxHf4Bs/7xtDCcPwEa2NU9DaG/g==",
    "license": "Apache-2.0",
    "dependencies": {
     "@swc/helpers": "^0.5.0"
    }
   },
   "node_modules/@internationalized/string": {
-   "version": "3.2.5",
-   "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.5.tgz",
-   "integrity": "sha512-rKs71Zvl2OKOHM+mzAFMIyqR5hI1d1O6BBkMK2/lkfg3fkmVh9Eeg0awcA8W2WqYqDOv6a86DIOlFpggwLtbuw==",
+   "version": "3.2.6",
+   "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.6.tgz",
+   "integrity": "sha512-LR2lnM4urJta5/wYJVV7m8qk5DrMZmLRTuFhbQO5b9/sKLHgty6unQy1Li4+Su2DWydmB4aZdS5uxBRXIq2aAw==",
    "license": "Apache-2.0",
    "dependencies": {
     "@swc/helpers": "^0.5.0"
@@ -7304,16 +7766,16 @@
    }
   },
   "node_modules/@react-aria/tooltip": {
-   "version": "3.8.0",
-   "resolved": "https://registry.npmjs.org/@react-aria/tooltip/-/tooltip-3.8.0.tgz",
-   "integrity": "sha512-Tal09bWgursZ3v1qUuB/0z4Cz+jcDIfe8G5TECMtr0vbfYh2u7RIjBNZnsRcxZ2syXDxhHrPNeh8mrp4vKCAKg==",
+   "version": "3.8.2",
+   "resolved": "https://registry.npmjs.org/@react-aria/tooltip/-/tooltip-3.8.2.tgz",
+   "integrity": "sha512-ctVTgh1LXvmr1ve3ehAWfvlJR7nHYZeqhl/g1qnA+983LQtc1IF9MraCs92g0m7KpBwCihuA+aYwTPsUHfKfXg==",
    "license": "Apache-2.0",
    "dependencies": {
-    "@react-aria/interactions": "^3.24.0",
-    "@react-aria/utils": "^3.28.0",
-    "@react-stately/tooltip": "^3.5.2",
-    "@react-types/shared": "^3.28.0",
-    "@react-types/tooltip": "^3.4.15",
+    "@react-aria/interactions": "^3.25.0",
+    "@react-aria/utils": "^3.28.2",
+    "@react-stately/tooltip": "^3.5.3",
+    "@react-types/shared": "^3.29.0",
+    "@react-types/tooltip": "^3.4.16",
     "@swc/helpers": "^0.5.0"
    },
    "peerDependencies": {
@@ -7321,10 +7783,72 @@
     "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
    }
   },
+  "node_modules/@react-aria/tooltip/node_modules/@react-aria/interactions": {
+   "version": "3.25.0",
+   "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.25.0.tgz",
+   "integrity": "sha512-GgIsDLlO8rDU/nFn6DfsbP9rfnzhm8QFjZkB9K9+r+MTSCn7bMntiWQgMM+5O6BiA8d7C7x4zuN4bZtc0RBdXQ==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@react-aria/ssr": "^3.9.8",
+    "@react-aria/utils": "^3.28.2",
+    "@react-stately/flags": "^3.1.1",
+    "@react-types/shared": "^3.29.0",
+    "@swc/helpers": "^0.5.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@react-aria/tooltip/node_modules/@react-aria/ssr": {
+   "version": "3.9.8",
+   "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.8.tgz",
+   "integrity": "sha512-lQDE/c9uTfBSDOjaZUJS8xP2jCKVk4zjQeIlCH90xaLhHDgbpCdns3xvFpJJujfj3nI4Ll9K7A+ONUBDCASOuw==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@swc/helpers": "^0.5.0"
+   },
+   "engines": {
+    "node": ">= 12"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@react-aria/tooltip/node_modules/@react-aria/utils": {
+   "version": "3.28.2",
+   "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.28.2.tgz",
+   "integrity": "sha512-J8CcLbvnQgiBn54eeEvQQbIOfBF3A1QizxMw9P4cl9MkeR03ug7RnjTIdJY/n2p7t59kLeAB3tqiczhcj+Oi5w==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@react-aria/ssr": "^3.9.8",
+    "@react-stately/flags": "^3.1.1",
+    "@react-stately/utils": "^3.10.6",
+    "@react-types/shared": "^3.29.0",
+    "@swc/helpers": "^0.5.0",
+    "clsx": "^2.0.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+    "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@react-aria/tooltip/node_modules/@react-stately/utils": {
+   "version": "3.10.6",
+   "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.6.tgz",
+   "integrity": "sha512-O76ip4InfTTzAJrg8OaZxKU4vvjMDOpfA/PGNOytiXwBbkct2ZeZwaimJ8Bt9W1bj5VsZ81/o/tW4BacbdDOMA==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@swc/helpers": "^0.5.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
   "node_modules/@react-aria/tooltip/node_modules/@react-types/shared": {
-   "version": "3.28.0",
-   "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.28.0.tgz",
-   "integrity": "sha512-9oMEYIDc3sk0G5rysnYvdNrkSg7B04yTKl50HHSZVbokeHpnU0yRmsDaWb9B/5RprcKj8XszEk5guBO8Sa/Q+Q==",
+   "version": "3.29.0",
+   "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.0.tgz",
+   "integrity": "sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==",
    "license": "Apache-2.0",
    "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
@@ -7703,15 +8227,62 @@
    }
   },
   "node_modules/@react-stately/tooltip": {
-   "version": "3.5.2",
-   "resolved": "https://registry.npmjs.org/@react-stately/tooltip/-/tooltip-3.5.2.tgz",
-   "integrity": "sha512-z81kwZWnnf2SE5/rHMrejH5uQu3dXUjrhIa2AGT038DNOmRyS9TkFBywPCiiE7tHpUg/rxZrPxx01JFGvOkmgg==",
+   "version": "3.5.3",
+   "resolved": "https://registry.npmjs.org/@react-stately/tooltip/-/tooltip-3.5.3.tgz",
+   "integrity": "sha512-btfy/gQ3Eccudx//4HkyQ+CRr3vxbLs74HYHthaoJ9GZbRj/3XDzfUM2X16zRoqTZVrIz/AkUj7AfGfsitU5nQ==",
    "license": "Apache-2.0",
    "dependencies": {
-    "@react-stately/overlays": "^3.6.14",
-    "@react-types/tooltip": "^3.4.15",
+    "@react-stately/overlays": "^3.6.15",
+    "@react-types/tooltip": "^3.4.16",
     "@swc/helpers": "^0.5.0"
    },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@react-stately/tooltip/node_modules/@react-stately/overlays": {
+   "version": "3.6.15",
+   "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.15.tgz",
+   "integrity": "sha512-LBaGpXuI+SSd5HSGzyGJA0Gy09V2tl2G/r0lllTYqwt0RDZR6p7IrhdGVXZm6vI0oWEnih7yLC32krkVQrffgQ==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@react-stately/utils": "^3.10.6",
+    "@react-types/overlays": "^3.8.14",
+    "@swc/helpers": "^0.5.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@react-stately/tooltip/node_modules/@react-stately/utils": {
+   "version": "3.10.6",
+   "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.10.6.tgz",
+   "integrity": "sha512-O76ip4InfTTzAJrg8OaZxKU4vvjMDOpfA/PGNOytiXwBbkct2ZeZwaimJ8Bt9W1bj5VsZ81/o/tW4BacbdDOMA==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@swc/helpers": "^0.5.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@react-stately/tooltip/node_modules/@react-types/overlays": {
+   "version": "3.8.14",
+   "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.14.tgz",
+   "integrity": "sha512-XJS67KHYhdMvPNHXNGdmc85gE+29QT5TwC58V4kxxHVtQh9fYzEEPzIV8K84XWSz04rRGe3fjDgRNbcqBektWQ==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@react-types/shared": "^3.29.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@react-stately/tooltip/node_modules/@react-types/shared": {
+   "version": "3.29.0",
+   "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.0.tgz",
+   "integrity": "sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==",
+   "license": "Apache-2.0",
    "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
    }
@@ -7842,22 +8413,31 @@
    }
   },
   "node_modules/@react-types/calendar": {
-   "version": "3.6.1",
-   "resolved": "https://registry.npmjs.org/@react-types/calendar/-/calendar-3.6.1.tgz",
-   "integrity": "sha512-EMbFJX/3gD5j+R0qZEGqK+wlhBxMSHhGP8GqP9XGbpuJPE3w9/M/PVWdh8FUdzf9srYxPOq5NgiGI1JUJvdZqw==",
+   "version": "3.7.0",
+   "resolved": "https://registry.npmjs.org/@react-types/calendar/-/calendar-3.7.0.tgz",
+   "integrity": "sha512-RiEfX2ZTcvfRktQc5obOJtNTgW+UwjNOUW5yf9CLCNOSM07e0w5jtC1ewsOZZbcctMrMCljjL8niGWiBv1wQ1Q==",
    "license": "Apache-2.0",
    "dependencies": {
-    "@internationalized/date": "^3.7.0",
-    "@react-types/shared": "^3.28.0"
+    "@internationalized/date": "^3.8.0",
+    "@react-types/shared": "^3.29.0"
    },
    "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
    }
   },
+  "node_modules/@react-types/calendar/node_modules/@internationalized/date": {
+   "version": "3.8.0",
+   "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.8.0.tgz",
+   "integrity": "sha512-J51AJ0fEL68hE4CwGPa6E0PO6JDaVLd8aln48xFCSy7CZkZc96dGEGmLs2OEEbBxcsVZtfrqkXJwI2/MSG8yKw==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@swc/helpers": "^0.5.0"
+   }
+  },
   "node_modules/@react-types/calendar/node_modules/@react-types/shared": {
-   "version": "3.28.0",
-   "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.28.0.tgz",
-   "integrity": "sha512-9oMEYIDc3sk0G5rysnYvdNrkSg7B04yTKl50HHSZVbokeHpnU0yRmsDaWb9B/5RprcKj8XszEk5guBO8Sa/Q+Q==",
+   "version": "3.29.0",
+   "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.0.tgz",
+   "integrity": "sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==",
    "license": "Apache-2.0",
    "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
@@ -8153,22 +8733,34 @@
    }
   },
   "node_modules/@react-types/tooltip": {
-   "version": "3.4.15",
-   "resolved": "https://registry.npmjs.org/@react-types/tooltip/-/tooltip-3.4.15.tgz",
-   "integrity": "sha512-qiYwQLiEwYqrt/m8iQA8abl9k/9LrbtMNoEevL4jN4H0I5NrG55E78GYTkSzBBYmhBO4KnPVT0SfGM1tYaQx/A==",
+   "version": "3.4.16",
+   "resolved": "https://registry.npmjs.org/@react-types/tooltip/-/tooltip-3.4.16.tgz",
+   "integrity": "sha512-XEyKeqR3YxqJcR0cpigLGEBeRTEzrB0cu++IaADdqXJ8dBzS6s8y9EgR5UvKZmX1CQOBvMfXyYkj7nmJ039fOw==",
    "license": "Apache-2.0",
    "dependencies": {
-    "@react-types/overlays": "^3.8.13",
-    "@react-types/shared": "^3.28.0"
+    "@react-types/overlays": "^3.8.14",
+    "@react-types/shared": "^3.29.0"
+   },
+   "peerDependencies": {
+    "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+   }
+  },
+  "node_modules/@react-types/tooltip/node_modules/@react-types/overlays": {
+   "version": "3.8.14",
+   "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.14.tgz",
+   "integrity": "sha512-XJS67KHYhdMvPNHXNGdmc85gE+29QT5TwC58V4kxxHVtQh9fYzEEPzIV8K84XWSz04rRGe3fjDgRNbcqBektWQ==",
+   "license": "Apache-2.0",
+   "dependencies": {
+    "@react-types/shared": "^3.29.0"
    },
    "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
    }
   },
   "node_modules/@react-types/tooltip/node_modules/@react-types/shared": {
-   "version": "3.28.0",
-   "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.28.0.tgz",
-   "integrity": "sha512-9oMEYIDc3sk0G5rysnYvdNrkSg7B04yTKl50HHSZVbokeHpnU0yRmsDaWb9B/5RprcKj8XszEk5guBO8Sa/Q+Q==",
+   "version": "3.29.0",
+   "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.29.0.tgz",
+   "integrity": "sha512-IDQYu/AHgZimObzCFdNl1LpZvQW/xcfLt3v20sorl5qRucDVj4S9os98sVTZ4IRIBjmS+MkjqpR5E70xan7ooA==",
    "license": "Apache-2.0",
    "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "@heroui/system": "2.4.11",
   "@heroui/table": "^2.2.15",
   "@heroui/theme": "2.4.11",
+  "@heroui/tooltip": "^2.2.16",
   "@react-aria/ssr": "3.9.7",
   "@react-aria/visually-hidden": "3.8.18",
   "@react-stately/data": "^3.12.1",


### PR DESCRIPTION
This commit introduces tooltip functionality to the product color selection component, enhancing user experience by providing additional information about each color option. The `@heroui/tooltip` package has been added to the project dependencies to support this feature. Additionally, minor adjustments were made to the `ProductColors` and `ProductDetails` components to improve accessibility and styling.