### PR TITLE
feat(service): add ServiceHero component for service page

### DIFF
--- a/app/(app)/services/[slug]/page.tsx
+++ b/app/(app)/services/[slug]/page.tsx
@@ -1,12 +1,9 @@
-import Image from 'next/image';
 import { SanityImageSource } from '@sanity/image-url/lib/types/types';
-import Link from 'next/link';
 import imageUrlBuilder from '@sanity/image-url';
 import { defineQuery, PortableText, SanityDocument } from 'next-sanity';
 
 import BaseBreadcrumb from '@/components/ui/Breadcrumb';
-import BrandButton from '@/components/ui/BrandButton';
-import { ServiceDetails } from '@/components/shared/service';
+import { ServiceDetails, ServiceHero } from '@/components/shared/service';
 import { client } from '@/sanity/client';
 import { getUrlFor } from '@/lib/utils';
 import { ProjectList, ProjectsHeading } from '@/components/shared/project';
@@ -18,8 +15,6 @@ import { clsx } from 'clsx';
 import { FAQSection } from '@/components/shared/faq';
 import { SECTION_FIELDS } from '@/sanity/lib/queries/page.query';
 import ServiceJsonLd from '@/components/ServiceJsonLd';
-import { BreadcrumbListJsonLd } from '@/components/ServiceJsonLd';
-import { MediaBlock } from '@/components/shared/media';
 
 type Props = {
     slug: string
@@ -86,39 +81,12 @@ export default async function ServicePage({ params }: { params: Promise<Props> }
     return (
         <>
             {/* Hero section with background image and gradient overlay */}
-            <section
-                className="py-12 md:py-24 relative after:absolute after:inset-0 after:bg-gradient-to-t after:from-black after:to-transparent overflow-hidden min-h-screen grid place-content-center">
-                {/* Background service image */}
-                {
-                    service.mediaBlock ?
-                        <div className='absolute inset-0'>
-                            <MediaBlock
-                                {...service.mediaBlock}
-                            />
-                        </div> :
-                        <Image
-                            priority
-                            alt={service.title}
-                            className="absolute inset-0 object-cover w-full h-full"
-                            height={1080}
-                            src={`${serviceImageUrl}`}
-                            width={1920}
-                        />
-                }
-                {/* Hero content */}
-                <div className="container flex flex-col gap-10 max-w-2xl relative z-10">
-                    <div className="text-center">
-                        <h1 className="text-4xl font-extrabold text-background sm:text-5xl">
-                            {service.title}
-                        </h1>
-                        <p className="mt-4 text-xl text-white text-balance">
-                            {service.description}
-                        </p>
-                    </div>
-
-                    <BrandButton as={Link} className={'self-center'} href={'#serviceDetails'} state="primary">Подробнее</BrandButton>
-                </div>
-            </section>
+            <ServiceHero
+                image={serviceImageUrl || ''}
+                title={service.title}
+                description={service.description}
+                mediaBlock={service.mediaBlock}
+            />
 
             {/* Main content wrapper */}
             <div className='max-w-3xl mx-auto'>

--- a/components/shared/media/MediaBlock.tsx
+++ b/components/shared/media/MediaBlock.tsx
@@ -19,12 +19,11 @@ export const MediaBlock: React.FC<MediaBlockProps> = async ({
                 src={url}
                 controls={false}
                 preload="metadata"
-                className="w-full h-full aspect-video absolute inset-0"
+                className="w-full h-full aspect-video absolute inset-0 object-contain"
                 autoPlay
                 loop
                 muted
                 playsInline
-                style={{ objectFit: 'cover' }}
             />
         ) : (
             <p className="text-red-500">Uploaded video not found</p>

--- a/components/shared/service/ServiceHero.tsx
+++ b/components/shared/service/ServiceHero.tsx
@@ -1,0 +1,57 @@
+import Image from 'next/image'
+import { MediaBlock } from '../media';
+import BrandButton from '@/components/ui/BrandButton';
+import Link from 'next/link';
+import { ServiceHeroProps } from './service.props';
+
+/**
+ * A strongly typed function that renders a hero section for a service.
+ *
+ * @param {ServiceHeroProps} props - The props object with required properties.
+ * @returns {JSX.Element} A JSX element that represents the hero section.
+ */
+
+export const ServiceHero: React.FC<ServiceHeroProps> = ({ title, description, mediaBlock, image, ...props }): JSX.Element => {
+    return (
+        <section
+            className="py-12 md:py-24 relative after:absolute after:inset-0 after:bg-gradient-to-t after:from-black after:to-transparent overflow-hidden min-h-[calc(100vh-64px)] grid place-content-center">
+            {/* Background service image */}
+            {
+                mediaBlock ?
+                    <div className='absolute inset-0'>
+                        <Image
+                            alt={title}
+                            className="absolute inset-0 object-cover w-full h-full blur"
+                            height={1080}
+                            src={`${image}`}
+                            width={1920}
+                        />
+                        <MediaBlock
+                            {...mediaBlock}
+                        />
+                    </div> :
+                    <Image
+                        priority
+                        alt={title}
+                        className="absolute inset-0 object-cover w-full h-full"
+                        height={1080}
+                        src={`${image}`}
+                        width={1920}
+                    />
+            }
+            {/* Hero content */}
+            <div className="container flex flex-col gap-10 max-w-2xl relative z-10">
+                <div className="text-center">
+                    <h1 className="text-4xl font-extrabold text-background sm:text-5xl">
+                        {title}
+                    </h1>
+                    <p className="mt-4 text-xl text-white text-balance">
+                        {description}
+                    </p>
+                </div>
+
+                <BrandButton as={Link} className={'self-center'} href={'#serviceDetails'} state="primary">Подробнее</BrandButton>
+            </div>
+        </section>
+    )
+}

--- a/components/shared/service/index.ts
+++ b/components/shared/service/index.ts
@@ -1,5 +1,6 @@
 import ServiceListItems from './_ServiceListItems';
 import { Services } from './Services';
 import { ServiceDetails } from './ServiceDetails';
+import { ServiceHero } from './ServiceHero';
 
-export { ServiceListItems, Services, ServiceDetails };
+export { ServiceListItems, Services, ServiceDetails, ServiceHero };

--- a/components/shared/service/service.props.ts
+++ b/components/shared/service/service.props.ts
@@ -1,0 +1,8 @@
+import { MediaBlockProps } from "@/components/shared/media/media.props";
+
+export type ServiceHeroProps = {
+    title: string;
+    description: string;
+    mediaBlock?: MediaBlockProps;
+    image?: string;
+};


### PR DESCRIPTION
Introduce a new ServiceHero component to handle the hero section of the service page. This component includes a background image, title, description, and a call-to-action button. The existing hero section in the service page has been replaced with this component to improve code reusability and maintainability.