### PR TITLE
feat(catalog-utils): add subcategory to grouped products

### DIFF
--- a/lib/catalog-utils.ts
+++ b/lib/catalog-utils.ts
@@ -59,6 +59,7 @@ export function groupProductsByCleanName(products: any[]) {
         description: product.general_description?.[0],
         variation_description: product.variation_description?.[0],
         category: product.category[0].split('|')[0],
+        subcategory: product.category[0].split('|')[1],
       };
     }
 


### PR DESCRIPTION
Enhance the `groupProductsByCleanName` function to include the subcategory extracted from the product category string. This provides more detailed product grouping information.