### PR TITLE
feat(seo): add google and yandex verification to metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -42,6 +42,10 @@ export const metadata: Metadata = {
   alternates: {
     canonical: 'https://artmarketprint.by',
   },
+  verification: {
+    google: '8YlcgzL83D40BFHx5ZMIaLjwHnFMG_kQ9XU_GJa4AaI',
+    yandex: 'ab836662e7e48a90',
+  },
 };
 
 export const viewport: Viewport = {
@@ -80,10 +84,6 @@ export default function RootLayout({
             `,
           }}
         />
-        {/* Google Search Console Verification */}
-        <meta name="google-site-verification" content="8YlcgzL83D40BFHx5ZMIaLjwHnFMG_kQ9XU_GJa4AaI" />
-        {/* Yandex.Metrika counter */}
-        <meta name="yandex-verification" content="ab836662e7e48a90" />
       </head>
       <body
         className={clsx(


### PR DESCRIPTION
Move search engine verification meta tags from HTML head to Next.js metadata configuration for better maintainability and consistency with the framework's recommended practices.