### PR TITLE
feat(home): add metadata generation for home page

### DIFF
--- a/app/(app)/page.tsx
+++ b/app/(app)/page.tsx
@@ -1,8 +1,19 @@
 import { HOME_PAGE_QUERY } from '@/sanity/lib/queries/page.query';
 import { PageBuilder } from '@/components/PageBuilder';
 import { sanityFetch } from '@/sanity/lib/sanityFetch';
+import { Metadata } from 'next';
+
+export async function generateMetadata(): Promise<Metadata> {
+	const data: any = await sanityFetch({ query: HOME_PAGE_QUERY });
+
+	return {
+		title: data?.homePage?.seo?.title,
+		description: data?.homePage?.seo?.description,
+	};
+}
+
 export default async function Home() {
-	const data: any = await sanityFetch({query: HOME_PAGE_QUERY});
+	const data: any = await sanityFetch({ query: HOME_PAGE_QUERY });
 
 	return (
 		<>


### PR DESCRIPTION
Add generateMetadata function to fetch and set SEO title and description from Sanity CMS. This improves SEO capabilities for the home page.