### PR TITLE
ci: add Netlify redirect configuration for domain migration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+from = "https://artmarketprint.netlify.app/*"
+to = "https://artmarketprint.by/:splat"
+status = 301
+force = true


### PR DESCRIPTION
Add 301 redirect rules to ensure all traffic from the old Netlify subdomain is properly redirected to the new custom domain