### PR TITLE
refactor(products): move price calculation to catalog utils

### DIFF
--- a/app/(app)/(store)/products/[slug]/page.tsx
+++ b/app/(app)/(store)/products/[slug]/page.tsx
@@ -4,7 +4,6 @@ import Section from '@/components/layout/Section';
 import { ProductCarousel, ProductDetails, ProductStock } from '@/components/shared/product';
 import RelatedProducts from '@/components/shared/product/RelatedProducts';
 import getProductBySlug from '@/sanity/lib/product/getProductBySlug';
-import {getPrice, priceTransform} from '@/lib/getPrice';
 import { NAVIGATION_QUERY } from '@/sanity/lib/queries';
 import AddToBasketButton from '@/components/ui/AddToBasketButton';
 import ProductPrice from '@/components/shared/product/ProductPrice';
@@ -14,7 +13,6 @@ import { ProductBreadcrumb } from '@/components/ui/Breadcrumb';
 import { OrderForm } from '@/components/ui/form';
 import clsx from 'clsx';
 import { getTotalStock } from "@/components/shared/product/lib";
-import {Companies} from "@/lib/products/companies";
 
 export interface Props {
 	slug: string;
@@ -72,6 +70,7 @@ export default async function ProductPage({ params }: { params: Promise<Props> }
 
 	const { id, name: productTitle = '', description: general_description = '', variation_description = '', price = [], colors, sizes, category, items, stock, sku } = (product as any) || {};
 	const totalStock = getTotalStock(items);
+	const productPrice = price;
 
 	return (
 		<>
@@ -82,7 +81,7 @@ export default async function ProductPage({ params }: { params: Promise<Props> }
 					<h1 className="text-2xl font-bold">
 						{productTitle}
 						{sku && (
-							<span className="text-sm text-gray-600 ml-2 font-light">арт. {sku}</span>
+							<span className="text-sm text-gray-600 ml-2 font-light truncate">арт. {sku}</span>
 						)}
 					</h1>
 				</div>
@@ -92,7 +91,7 @@ export default async function ProductPage({ params }: { params: Promise<Props> }
 						<Card className="bg-indigo-100">
 							<CardBody>
 								<p className="my-0">
-									<ProductPrice price={getPrice(price, (1 - priceTransform(Companies.ARTE.discount)))} productId={id} />
+									<ProductPrice price={productPrice} productId={id} />
 								</p>
 								<ProductStock items={items} />
 							</CardBody>

--- a/components/shared/product/ProductList.tsx
+++ b/components/shared/product/ProductList.tsx
@@ -1,7 +1,5 @@
 import {BrandCard} from '@/components/ui/card';
-import {getPrice, priceTransform} from '@/lib/getPrice';
 import { ProductData } from './product.types';
-import {Companies} from "@/lib/products/companies";
 
 export default function ProductList({ items }: { items: ProductData[]}) {
   return (
@@ -17,7 +15,7 @@ export default function ProductList({ items }: { items: ProductData[]}) {
                 href={`/products/${item.id}`}
                 image={item.image}
                 imageFit="contain"
-                price={`${getPrice(item?.price, (1 - priceTransform(Companies.ARTE.discount)))} BYN`}
+                price={`${item?.price} BYN`}
                 title={item.name}
                 variant="product"
               />

--- a/components/shared/product/ProductThumb.tsx
+++ b/components/shared/product/ProductThumb.tsx
@@ -8,10 +8,8 @@ import { Image } from '@heroui/image';
 import { ProductColors } from './ProductColors';
 import { ProductSizes } from './ProductSizes';
 
-import {getPrice, priceTransform} from '@/lib/getPrice';
 import { ProductData } from '@/components/shared/product/product.types';
 import {getTotalStock} from '@/components/shared/product/lib';
-import {Companies} from "@/lib/products/companies";
 
 interface ProductThumbProps extends React.HTMLAttributes<HTMLDivElement> {
     item: ProductData;
@@ -24,7 +22,7 @@ interface ProductThumbProps extends React.HTMLAttributes<HTMLDivElement> {
  */
 const ProductThumb: FC<ProductThumbProps> = ({ item, ...props }) => {
     const id = item._id;
-    const price = getPrice(item.price, (1 - priceTransform(Companies.ARTE.discount)));
+    const price = item.price;
     const name = item.name;
     const image = item.image;
     const totalStock = getTotalStock(item.items);

--- a/lib/products/catalog-utils.ts
+++ b/lib/products/catalog-utils.ts
@@ -1,3 +1,6 @@
+import { getPrice, priceTransform } from "../getPrice";
+import { Companies } from "./companies";
+
 // Типы товара
 export interface RawProduct {
   _id: string;
@@ -52,7 +55,7 @@ export function groupProductsByCleanName(products: any[]) {
         colors: new Set(),
         sizes: new Set(),
         items: new Map<string, { id: string, images_urls: string, color: string, cover: string, stock: string, sku: string }>(), // Map to store unique variations
-        price: product.price?.[0],
+        price: getPrice(product.price?.[0], (1 - priceTransform(Companies.ARTE.discount))),
         url: product.url?.[0],
         image: product.images_urls[0]?.split(',')[0],
         images_urls: product.images_urls?.[0],


### PR DESCRIPTION
Centralize price calculation logic in catalog-utils.ts instead of computing it in multiple components. This improves maintainability by having a single source of truth for product prices.