### PR TITLE
feat(filter): add accordion state reset when category is cleared

### DIFF
--- a/components/shared/product/ProductsFilter.tsx
+++ b/components/shared/product/ProductsFilter.tsx
@@ -25,8 +25,8 @@ interface FilterGroupProps {
 export const FilterGroup: FC<FilterGroupProps> = ({sortOrder, selectedCategory, categories, onFilterChange}) => {
 	return (
 		<Form className="flex flex-col gap-4">
-			{SortFilter({sortOrder, selectedCategory, onFilterChange})}
-			{categories && CatFilter({sortOrder, onFilterChange, categories, selectedCategory})}
+			<SortFilter sortOrder={sortOrder} selectedCategory={selectedCategory} onFilterChange={onFilterChange} />
+			{categories && <CatFilter sortOrder={sortOrder} onFilterChange={onFilterChange} categories={categories} selectedCategory={selectedCategory} />}
 			<Button color="default" radius="sm" variant="solid" type="reset" onPress={() => onFilterChange('asc', '')}>
 				Сбросить
 			</Button>
@@ -69,7 +69,14 @@ interface FilterDrawerProps {
  * @returns {JSX.Element} The rendered FilterDrawer component.
  */
 export const FilterDrawer: FC<FilterDrawerProps> = ({isOpen, onOpenChange, onFilterChange, categories, sortOrder, selectedCategory}) => {
-	const categoriesSet = categories ? CatFilter({sortOrder, onFilterChange, categories, selectedCategory}) : null;
+	const categoriesSet = categories ? (
+		<CatFilter 
+			sortOrder={sortOrder} 
+			onFilterChange={onFilterChange} 
+			categories={categories} 
+			selectedCategory={selectedCategory} 
+		/>
+	) : null;
 
 	return (
 		<Drawer isOpen={isOpen} onOpenChange={onOpenChange} radius="none">

--- a/components/shared/product/ProductsFilter.tsx
+++ b/components/shared/product/ProductsFilter.tsx
@@ -1,19 +1,19 @@
 'use client';
-import { Button } from '@heroui/button';
-import { Drawer, DrawerBody, DrawerContent, DrawerFooter, DrawerHeader } from '@heroui/drawer';
-import { FilterIcon } from 'lucide-react';
+import {Button} from '@heroui/button';
+import {Drawer, DrawerBody, DrawerContent, DrawerFooter, DrawerHeader} from '@heroui/drawer';
+import {FilterIcon} from 'lucide-react';
 import React from 'react';
-import { Form } from '@heroui/form';
+import {Form} from '@heroui/form';
 
-import { FC } from 'react';
-import { CategoryProps, CatFilter } from '@/components/ui/filter/CatFilter';
-import { SortFilter } from '@/components/ui/filter/SortFilter';
+import {FC} from 'react';
+import {CategoryProps, CatFilter} from '@/components/ui/filter/CatFilter';
+import {SortFilter} from '@/components/ui/filter/SortFilter';
 
 interface FilterGroupProps {
-  sortOrder: string;
-  selectedCategory: string;
-  categories: CategoryProps[];
-  onFilterChange: (sortOrder: string, category: string) => void;
+	sortOrder: string;
+	selectedCategory: string;
+	categories: CategoryProps[];
+	onFilterChange: (sortOrder: string, category: string) => void;
 }
 
 /**
@@ -22,20 +22,20 @@ interface FilterGroupProps {
  * @param {FilterGroupProps} props - The properties for the FilterGroup component.
  * @returns {JSX.Element} The rendered FilterGroup component.
  */
-export const FilterGroup: FC<FilterGroupProps> = ({ sortOrder, selectedCategory, categories, onFilterChange }) => {
-  return (
-    <Form className='flex flex-col gap-4'>
-      {SortFilter({ sortOrder, selectedCategory, onFilterChange })}
-      {categories && CatFilter({ sortOrder, onFilterChange, categories })}
-      <Button color="default" radius='sm' variant="solid" type='reset' onPress={() => onFilterChange('asc', '')}>
-        Сбросить
-      </Button>
-    </Form>
-  );
+export const FilterGroup: FC<FilterGroupProps> = ({sortOrder, selectedCategory, categories, onFilterChange}) => {
+	return (
+		<Form className="flex flex-col gap-4">
+			{SortFilter({sortOrder, selectedCategory, onFilterChange})}
+			{categories && CatFilter({sortOrder, onFilterChange, categories, selectedCategory})}
+			<Button color="default" radius="sm" variant="solid" type="reset" onPress={() => onFilterChange('asc', '')}>
+				Сбросить
+			</Button>
+		</Form>
+	);
 };
 
 interface FilterButtonProps {
-  onOpen: () => void;
+	onOpen: () => void;
 }
 
 /**
@@ -44,22 +44,22 @@ interface FilterButtonProps {
  * @param {FilterButtonProps} props - The properties for the FilterButton component.
  * @returns {JSX.Element} The rendered FilterButton component.
  */
-export const FilterButton: FC<FilterButtonProps> = ({ onOpen }) => {
-  return (
-    <Button className='flex-grow min-w-max border-1 sticky top-20' radius='sm' color='default' variant='bordered' onPress={onOpen}>
-      <FilterIcon size={16} />
-      <span className='text-sm'>Фильтры по товарам</span>
-    </Button>
-  );
+export const FilterButton: FC<FilterButtonProps> = ({onOpen}) => {
+	return (
+		<Button className="flex-grow min-w-max border-1 sticky top-20" radius="sm" color="default" variant="bordered" onPress={onOpen}>
+			<FilterIcon size={16} />
+			<span className="text-sm">Фильтры по товарам</span>
+		</Button>
+	);
 };
 
 interface FilterDrawerProps {
-  isOpen: boolean;
-  onOpenChange: (isOpen: boolean) => void;
-  onFilterChange: (sortOrder: string, category: string) => void;
-  categories: CategoryProps[];
-  sortOrder: string;
-  selectedCategory: string;
+	isOpen: boolean;
+	onOpenChange: (isOpen: boolean) => void;
+	onFilterChange: (sortOrder: string, category: string) => void;
+	categories: CategoryProps[];
+	sortOrder: string;
+	selectedCategory: string;
 }
 
 /**
@@ -68,47 +68,42 @@ interface FilterDrawerProps {
  * @param {FilterDrawerProps} props - The properties for the FilterDrawer component.
  * @returns {JSX.Element} The rendered FilterDrawer component.
  */
-export const FilterDrawer: FC<FilterDrawerProps> = ({ isOpen, onOpenChange, onFilterChange, categories, sortOrder, selectedCategory }) => {
-  const categoriesSet = categories
-    ?
-    CatFilter({ sortOrder, onFilterChange, categories })
-    : null;
+export const FilterDrawer: FC<FilterDrawerProps> = ({isOpen, onOpenChange, onFilterChange, categories, sortOrder, selectedCategory}) => {
+	const categoriesSet = categories ? CatFilter({sortOrder, onFilterChange, categories, selectedCategory}) : null;
 
-  return (
-    <Drawer isOpen={isOpen} onOpenChange={onOpenChange} radius='none'>
-      <DrawerContent>
-        {(onClose) => (
-          <>
-            <DrawerHeader className="flex flex-col gap-1">Фильтры по товарам</DrawerHeader>
-            <Form className='left-0w-full items-stretch'>
-              <DrawerBody className='pb-20'>
-                {categoriesSet}
-              </DrawerBody>
-              {selectedCategory && (
-                <DrawerFooter className='absolute left-0 right-0 bottom-0 w-full bg-background border-t-1'>
-                  {/* Reset button to clear filters */}
-                  <Button color="default" radius='sm' variant="solid" type='reset' onPress={() => onFilterChange('asc', '')}>
-                    Сбросить
-                  </Button>
-                  {/* Apply button to close the drawer */}
-                  <Button color="primary" radius='sm' variant="solid" onPress={onClose}>
-                    Применить
-                  </Button>
-                </DrawerFooter>
-              )}
-            </Form>
-          </>
-        )}
-      </DrawerContent>
-    </Drawer>
-  );
+	return (
+		<Drawer isOpen={isOpen} onOpenChange={onOpenChange} radius="none">
+			<DrawerContent>
+				{(onClose) => (
+					<>
+						<DrawerHeader className="flex flex-col gap-1">Фильтры по товарам</DrawerHeader>
+						<Form className="left-0w-full items-stretch">
+							<DrawerBody className="pb-20">{categoriesSet}</DrawerBody>
+							{selectedCategory && (
+								<DrawerFooter className="absolute left-0 right-0 bottom-0 w-full bg-background border-t-1">
+									{/* Reset button to clear filters */}
+									<Button color="default" radius="sm" variant="solid" type="reset" onPress={() => onFilterChange('asc', '')}>
+										Сбросить
+									</Button>
+									{/* Apply button to close the drawer */}
+									<Button color="primary" radius="sm" variant="solid" onPress={onClose}>
+										Применить
+									</Button>
+								</DrawerFooter>
+							)}
+						</Form>
+					</>
+				)}
+			</DrawerContent>
+		</Drawer>
+	);
 };
 
 interface ProductsFilterProps {
-  sortOrder: string;
-  selectedCategory: string;
-  onFilterChange: (sortOrder: string, category: string) => void;
-  categories: CategoryProps[];
+	sortOrder: string;
+	selectedCategory: string;
+	onFilterChange: (sortOrder: string, category: string) => void;
+	categories: CategoryProps[];
 }
 
 /**
@@ -117,12 +112,12 @@ interface ProductsFilterProps {
  * @param {ProductsFilterProps} props - The properties for the ProductsFilter component.
  * @returns {JSX.Element} The rendered ProductsFilter component.
  */
-const ProductsFilter: FC<ProductsFilterProps> = ({ sortOrder, selectedCategory, onFilterChange, categories }) => {
-  return (
-    <div className='hidden md:flex flex-col gap-4 sticky top-20 z-30 bg-background'>
-      <FilterGroup categories={categories} selectedCategory={selectedCategory} sortOrder={sortOrder} onFilterChange={onFilterChange} />
-    </div>
-  );
+const ProductsFilter: FC<ProductsFilterProps> = ({sortOrder, selectedCategory, onFilterChange, categories}) => {
+	return (
+		<div className="hidden md:flex flex-col gap-4 sticky top-20 z-30 bg-background">
+			<FilterGroup categories={categories} selectedCategory={selectedCategory} sortOrder={sortOrder} onFilterChange={onFilterChange} />
+		</div>
+	);
 };
 
 export default ProductsFilter;

--- a/components/ui/filter/CatFilter.tsx
+++ b/components/ui/filter/CatFilter.tsx
@@ -2,7 +2,7 @@
 import { Accordion, AccordionItem } from "@heroui/accordion";
 import { Radio, RadioGroup } from "@heroui/radio";
 import { ScrollShadow } from "@heroui/scroll-shadow";
-import {FC, JSX} from "react";
+import React, {FC, useState} from "react";
 
 export interface CategoryProps {
     category: string;
@@ -14,6 +14,7 @@ interface CatFilterProps {
     sortOrder: string;
     onFilterChange: (sortOrder: string, category: string) => void;
     categories: CategoryProps[];
+    selectedCategory: string
 }
 
 /**
@@ -22,15 +23,23 @@ interface CatFilterProps {
  * @param {CatFilterProps} props - The properties for the CatFilter component.
  * @returns {JSX.Element} The rendered CatFilter component.
  */
-export const CatFilter: ({sortOrder, onFilterChange, categories}: {
-    sortOrder: any;
-    onFilterChange: any;
-    categories: any
-}) => JSX.Element = ({ sortOrder, onFilterChange, categories }) => {
+export const CatFilter: FC<CatFilterProps> = ({ sortOrder, onFilterChange, categories, selectedCategory }) => {
+    const [selectedKeys, setSelectedKeys] = React.useState<Set<React.Key>>(new Set());
+    
+    // Reset accordion state when selectedCategory is cleared
+    React.useEffect(() => {
+        if (!selectedCategory) {
+            setSelectedKeys(new Set());
+        }
+    }, [selectedCategory]);
+    
+
     return (
         <div className='flex gap-4 w-full'>
             <ScrollShadow className="w-full max-h-[calc(85vh-128px)]" size={50} hideScrollBar>
                 <Accordion
+                    selectedKeys={selectedKeys || new Set()}
+                    onSelectionChange={(keys) => setSelectedKeys(keys as Set<React.Key>)}
                     className="px-0 shadow-small rounded-small bg-content1 overflow-x-hidden"
                     defaultExpandedKeys={categories.length === 1 ? ['0'] : []}
                     itemClasses={{

--- a/components/ui/filter/CatFilter.tsx
+++ b/components/ui/filter/CatFilter.tsx
@@ -2,7 +2,7 @@
 import { Accordion, AccordionItem } from "@heroui/accordion";
 import { Radio, RadioGroup } from "@heroui/radio";
 import { ScrollShadow } from "@heroui/scroll-shadow";
-import React, {FC, useState} from "react";
+import React, {FC} from "react";
 
 export interface CategoryProps {
     category: string;
@@ -24,7 +24,7 @@ interface CatFilterProps {
  * @returns {JSX.Element} The rendered CatFilter component.
  */
 export const CatFilter: FC<CatFilterProps> = ({ sortOrder, onFilterChange, categories, selectedCategory }) => {
-    const [selectedKeys, setSelectedKeys] = React.useState<Set<React.Key>>(new Set());
+    const [selectedKeys, setSelectedKeys] = React.useState<Set<string>>(new Set());
     
     // Reset accordion state when selectedCategory is cleared
     React.useEffect(() => {
@@ -38,8 +38,8 @@ export const CatFilter: FC<CatFilterProps> = ({ sortOrder, onFilterChange, categ
         <div className='flex gap-4 w-full'>
             <ScrollShadow className="w-full max-h-[calc(85vh-128px)]" size={50} hideScrollBar>
                 <Accordion
-                    selectedKeys={selectedKeys || new Set()}
-                    onSelectionChange={(keys) => setSelectedKeys(keys as Set<React.Key>)}
+                    selectedKeys={selectedKeys}
+                    onSelectionChange={(keys) => setSelectedKeys(keys as Set<string>)}
                     className="px-0 shadow-small rounded-small bg-content1 overflow-x-hidden"
                     defaultExpandedKeys={categories.length === 1 ? ['0'] : []}
                     itemClasses={{


### PR DESCRIPTION
Add state management for accordion component to reset when selectedCategory is cleared. Pass selectedCategory prop to CatFilter component to enable this behavior.