### PR TITLE
refactor(sanity): use env vars for project ID and dataset configuration

### DIFF
--- a/sanity/client.ts
+++ b/sanity/client.ts
@@ -1,8 +1,8 @@
 import { createClient } from 'next-sanity';
 
 export const client = createClient({
-    projectId: 'p5q8f9ac',
-    dataset: 'production',
+    projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID,
+    dataset: process.env.NEXT_PUBLIC_SANITY_DATASET,
     apiVersion: '2024-01-01',
     token: process.env.NEXT_PUBLIC_SANITY_TOKEN,
     useCdn: true,


### PR DESCRIPTION
Move hardcoded Sanity project ID and dataset values to environment variables for better security and configuration flexibility