### PR TITLE
fix: update calculator title to match new branding

### DIFF
--- a/app/(app)/calculator/page.tsx
+++ b/app/(app)/calculator/page.tsx
@@ -7,7 +7,7 @@ export const metadata = {
 };
 
 export default async function CalculatorPage() {
-  const data = await getCalculatorByTitle('Калькулятор пакетов');
+  const data = await getCalculatorByTitle('Калькулятор стоимости пакетов ArtMarketPrint');
   console.log(data);
 
   return (


### PR DESCRIPTION
The calculator title was updated to reflect the new branding name "ArtMarketPrint" for consistency across the application.