### PR TITLE
ci(netlify): simplify redirect rules by using wildcard domain

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,5 @@
 [[redirects]]
-from = "https://develop--artmarketprint.netlify.app/*"
-to = "https://artmarketprint.by/:splat"
-status = 301
-force = true
-
-[[redirects]]
-from = "https://artmarketprint.netlify.app/*"
-to = "https://artmarketprint.by/:splat"
-status = 301
-force = true
+  from = "https://*.artmarketprint.netlify.app/*"
+  to = "https://artmarketprint.by/:splat"
+  status = 301
+  force = true


### PR DESCRIPTION
Replace multiple specific domain redirects with a single wildcard rule to handle all subdomains of artmarketprint.netlify.app