### PR TITLE
ci: update netlify redirect to use wildcard domain

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [[redirects]]
-  from = "https://*.artmarketprint.netlify.app/*"
+  from = "https://*.netlify.app/*"
   to = "https://artmarketprint.by/:splat"
   status = 301
   force = true


### PR DESCRIPTION
The previous redirect was too specific to artmarketprint.netlify.app. Updated to use the generic *.netlify.app wildcard to handle all Netlify subdomains.