### PR TITLE
chore: update netlify redirects configuration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [[redirects]]
-from = "https://*.netlify.app/*"
+from = "https://artmarketprint.netlify.app/*"
 to = "https://artmarketprint.by/:splat"
 status = 301
 force = true

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,2 @@
+https://develop--artmarketprint.netlify.app/*  https://artmarketprint.by/:splat  301!
+https://artmarketprint.netlify.app/*  https://artmarketprint.by/:splat  301!


### PR DESCRIPTION
Update redirect rules in netlify.toml and public_redirects to properly handle domain redirections from development and production Netlify URLs to the main domain.