### PR TITLE
fix: remove duplicate key in MaterialFilter component

### DIFF
--- a/components/ui/filter/MaterialFilter.tsx
+++ b/components/ui/filter/MaterialFilter.tsx
@@ -33,7 +33,7 @@ export const MaterialFilter: ({
       onChange={(e) => onFilterChange(sortOrder, '', e.target.value)}
       items={materials}
     >
-      <SelectItem textValue="Все материалы" key="Все материалы">
+      <SelectItem textValue="Все материалы" key="">
         Все материалы
       </SelectItem>
       {materials?.map((item: { material: string; count: number }) => (


### PR DESCRIPTION
The SelectItem component had a duplicate key prop that matched its textValue. This could cause React rendering issues. Removed the key value to let React handle it automatically.