### PR TITLE
refactor(product): remove variation_description from product search q…

### DIFF
--- a/sanity/lib/product/searchProductsByName.ts
+++ b/sanity/lib/product/searchProductsByName.ts
@@ -17,7 +17,6 @@ export async function searchProductsByName(searchParam: string): Promise<any[]> 
         `*[_type == "product" && (
             name match "${searchParam}*" ||
             description match "${searchParam}*" ||
-            variation_description match "${searchParam}*" ||
             category match "${searchParam}*"
         )]`
     );


### PR DESCRIPTION
…uery

The field variation_description is no longer needed in the product search functionality, simplifying the query and improving maintainability.