### PR TITLE
refactor(product): change category type from string to any in query

### DIFF
--- a/components/shared/product/lib/queries.ts
+++ b/components/shared/product/lib/queries.ts
@@ -1,10 +1,10 @@
 // lib/queries.ts
 import {defineQuery} from "next-sanity";
 
-export const getProductsQuery = (category: string | null, page: number, limit: number) => {
+export const getProductsQuery = (category: any | null, page: number, limit: number) => {
 	const start = (page - 1) * limit;
 	const categoryFilter = category ? `&& category == "${category.title}"` : '';
-	console.log(category);
+
 	return `
     *[_type == "product" ${categoryFilter}] | order(_createdAt desc) [${start}...${start + limit}] {
       _id,


### PR DESCRIPTION
The category parameter type was changed to 'any' to handle cases where the category object might be passed directly instead of just the title string. This provides more flexibility in how the query can be called while maintaining the same functionality.