### PR TITLE
ci(deploy): specify ssh port in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,4 +22,4 @@ jobs:
 
       - name: Deploy to VPS
         run: |
-          ssh ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "cd /home && ./deploy.sh"
+          ssh -p 2200 ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "cd /home && ./deploy.sh"


### PR DESCRIPTION
The VPS requires SSH connections on port 2200, so we need to explicitly specify this port in the deployment command.