### PR TITLE
fix(InstagramFeed): uncomment InstagramFeedOld component

### DIFF
--- a/components/shared/socials/InstagramFeed.tsx
+++ b/components/shared/socials/InstagramFeed.tsx
@@ -52,7 +52,7 @@ export const InstagramFeedSection = ({ className }: SectionProps) => {
                     </SectionDescription>
                 </SectionHeading>
             </div>
-            {/*<InstagramFeedOld />*/}
+            <InstagramFeedOld />
         </Section>
     )
 }


### PR DESCRIPTION
The component was previously commented out for testing purposes and needs to be restored for production use.