### PR TITLE
fix(calculator): update price calculation for white bags

### DIFF
--- a/components/shared/сalculator/lib/utils.ts
+++ b/components/shared/сalculator/lib/utils.ts
@@ -41,7 +41,7 @@ const calculatePVDPrice = (priceTable: any, selectedSize: Size, selectedPrint: a
 		}
 	}
 
-	return selectedColor?.id === 'white' ? pricePerBagValue : pricePerBagValue + COLOR_EXTRA_PRICE.colored;
+	return selectedColor?.id === 'white' ? (pricePerBagValue + COLOR_EXTRA_PRICE.DEFAULT) : (pricePerBagValue + COLOR_EXTRA_PRICE.colored);
 };
 
 export {getAvailableColors, getAvailableSizes, calculatePVDPrice};

--- a/components/shared/сalculator/mock-data.ts
+++ b/components/shared/сalculator/mock-data.ts
@@ -47,8 +47,8 @@ export const colors: Color[] = [
 ];
 
 export const COLOR_EXTRA_PRICE = {
-	DEFAULT: 0,
-	colored: 0.08,
+	DEFAULT: 0.05,
+	colored: 0.13,
 };
 
 export const sizes: Size[] = [


### PR DESCRIPTION
The DEFAULT color price was incorrectly set to 0, causing white bags to not include the base color charge. Now both DEFAULT and colored prices include their respective base charges, ensuring correct total price calculation.