### PR TITLE
chore: remove Google Tag Manager script from layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -80,18 +80,6 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
 	return (
 		<html suppressHydrationWarning lang="ru">
 			<head>
-				{/* Google Tag Manager */}
-				<Script id="google-tag-manager" strategy="afterInteractive">
-					{`
-            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-            })(window,document,'script','dataLayer','${GTM_ID}');
-          `}
-				</Script>
-				{/* End Google Tag Manager */}
-
 				{/* Yandex.Metrika counter */}
 				<Script
 					dangerouslySetInnerHTML={{


### PR DESCRIPTION
The script was removed as part of cleanup since Google Tag Manager is no longer used in the application, while Yandex.Metrika remains.