### PR TITLE
feat(service): conditionally render calculator button in service hero

### DIFF
--- a/app/(app)/services/[slug]/page.tsx
+++ b/app/(app)/services/[slug]/page.tsx
@@ -87,7 +87,7 @@ export default async function ServicePage({params}: {params: Promise<Props>}): P
 	return (
 		<>
 			{/* Hero section with background image and gradient overlay */}
-			<ServiceHero description={service.description} image={serviceImageUrl || ''} mediaBlock={service.mediaBlock} title={service.title} />
+			<ServiceHero description={service.description} image={serviceImageUrl || ''} mediaBlock={service.mediaBlock} title={service.title} calculator={service.calculator} />
 
 			{/* Main content wrapper */}
 			<div className="">

--- a/components/shared/service/ServiceHero.tsx
+++ b/components/shared/service/ServiceHero.tsx
@@ -21,7 +21,7 @@ import { CalculatorIcon } from 'lucide-react';
  * @returns {JSX.Element} A JSX element that represents the hero section.
  */
 
-export const ServiceHero: React.FC<ServiceHeroProps> = ({title, description, mediaBlock, image, ...props}): JSX.Element => {
+export const ServiceHero: React.FC<ServiceHeroProps> = ({title, description, mediaBlock, image, calculator}): JSX.Element => {
 	return (
 		<section className="py-12 md:py-24 relative after:absolute after:inset-0 after:bg-linear-to-t after:from-black/90 after:to-black/20 overflow-hidden grid place-items-end">
 			{/* Background service image */}
@@ -39,13 +39,14 @@ export const ServiceHero: React.FC<ServiceHeroProps> = ({title, description, med
 					<h1 className="text-4xl font-extrabold text-background sm:text-5xl uppercase text-balance">{title}</h1>
 					<p className="mt-4 md:text-lg text-white text-pretty">{description}</p>
 				</div>
-
-				<Link className="flex flex-col gap-2 md:flex-row self-center" href={'/calculator'}>
-					<BrandButton size="md" state="primary">
-						<CalculatorIcon size={18} />
-						Рассчитать стоимость
-					</BrandButton>
-				</Link>
+				{calculator && (
+					<Link className="flex flex-col gap-2 md:flex-row self-center" href={'/calculator'}>
+						<BrandButton size="md" state="primary">
+							<CalculatorIcon size={18} />
+							Рассчитать стоимость
+						</BrandButton>
+					</Link>
+				)}
 			</div>
 		</section>
 	);

--- a/components/shared/service/service.props.ts
+++ b/components/shared/service/service.props.ts
@@ -5,4 +5,5 @@ export type ServiceHeroProps = {
     description: string;
     mediaBlock?: MediaBlockProps;
     image?: string;
+    calculator?: string;
 };


### PR DESCRIPTION
Add optional calculator prop to ServiceHero component to control visibility of the cost calculator button. This allows individual service pages to show or hide the calculator link based on service configuration.