### PR TITLE
feat(search): persist selected color across product navigation

### DIFF
--- a/app/(app)/(store)/products/[slug]/page.tsx
+++ b/app/(app)/(store)/products/[slug]/page.tsx
@@ -64,8 +64,11 @@ export const generateMetadata = async ({params}: {params: Promise<Props>}) => {
 	};
 };
 
-export default async function ProductPage({params}: {params: Promise<Props>}) {
+export default async function ProductPage({params, searchParams}: {params: Promise<Props>, searchParams?: Promise<{color?: string}>}) {
 	const {slug} = await params;
+	const resolvedSearchParams = searchParams ? await searchParams : {};
+	const {color: selectedColorFromUrl} = resolvedSearchParams;
+
 	const [breadcrumbs, product] = await Promise.all([getSanityDocuments(NAVIGATION_QUERY), getProductBySlug(slug)]);
 
 	if (!product || product.length === 0)
@@ -117,7 +120,7 @@ export default async function ProductPage({params}: {params: Promise<Props>}) {
 							</CardBody>
 							<CardBody>
 								<ProductDetails
-									color={items?.[0]?.color || ''}
+									color={selectedColorFromUrl || items?.[0]?.color || ''}
 									colors={colors || []}
 									items={
 										items?.map((item: any) => ({

--- a/components/search.tsx
+++ b/components/search.tsx
@@ -321,14 +321,16 @@ const HitsList = memo(function HitsList({
       {hits.map((hit: any, idx: number) => {
         const isSel = selectedIndex === idx;
         const mappedImageUrl = getByPath<string>(hit, mapping.image);
-        const imageUrl = pickRelevantImageForQuery(
+        const relevant = pickRelevantImageForQuery(
           {
             ...hit,
             imageUrl: mappedImageUrl ?? hit.imageUrl,
           },
           query,
         );
-        const url = getByPath<string>(hit, mapping.url);
+        const imageUrl = relevant.image;
+        const color = relevant.color || '';
+        const url = `${getByPath<string>(hit, mapping.url)}?color=${color}`;
         const hasImage = Boolean(imageUrl);
         const isImageFailed = failedImages[hit.objectID] || !hasImage;
         const primaryVal = getByPath<string>(hit, mapping.primaryText);

--- a/components/shared/product/ProductDetails.tsx
+++ b/components/shared/product/ProductDetails.tsx
@@ -12,6 +12,7 @@ import Loader from '@/components/ui/Loader';
 
 import ProductSizeTable from './ProductSizeTable';
 import {ColorItemProps, ColorListItem, computedItems, MoreButton} from './ProductColors';
+import { setSelectedColorURL } from './lib';
 
 /**
  * A component to display a product thumbnail.
@@ -50,9 +51,14 @@ export const ProductDetails: ({items, sizes, colors, color, size}: {
 
     useEffect(() => {
         setIsClient(true);
-        if (colors[0]) setSelectedColor(colors[0]);
+        // Use the color prop if provided (from URL), otherwise use the first color
+        if (color) {
+            setSelectedColor(color);
+        } else if (colors[0]) {
+            setSelectedColor(colors[0]);
+        }
         if (sizes[0]) setSelectedSize(sizes[0]);
-    }, []);
+    }, [color, colors, sizes]);
 
     if (!isClient) return <Loader className='static text-primary flex mx-auto' size='md' variant='spinner' />;
 
@@ -75,6 +81,7 @@ export const ProductDetails: ({items, sizes, colors, color, size}: {
                             value={selectedColor}
                             onChange={(value) => {
                                 setSelectedColor(value.target.value)
+                                setSelectedColorURL(value.target.value);
                             }}
                         >
                             {

--- a/components/shared/product/lib/index.ts
+++ b/components/shared/product/lib/index.ts
@@ -47,3 +47,9 @@ export const getTotalStock = (items: any[]) => () => {
 
     return items.reduce((total, item) => total + Number(item.stock), 0);
 };
+
+export const setSelectedColorURL = (color: string) => {
+    const urlParams = new URLSearchParams(window.location.search);
+    urlParams.set('color', color);
+    window.history.pushState({}, '', `?${urlParams.toString()}`);
+};

--- a/components/shared/product/product.types.ts
+++ b/components/shared/product/product.types.ts
@@ -4,6 +4,7 @@ export interface ProductData {
     name: string;
     price: number;
     image: string;
+    activeColor: string;
     images: string[];
     images_urls: string;
     description: string;

--- a/components/shared/product/ui/ProductThumb.tsx
+++ b/components/shared/product/ui/ProductThumb.tsx
@@ -31,10 +31,11 @@ const ProductThumb: FC<ProductThumbProps> = ({ item, ...props }): JSX.Element =>
 	const totalStock = getTotalStock(item.items);
 	const brand = item.brand || '';
 	const category = item.category || '';
+	const activeColor = item.activeColor || '';
 
 	return (
 		<Card  className={clsx('h-full group relative max-w-full shadow-small hover:shadow-large transition-all duration-300', props.className)}  radius="sm">
-			<CardBody as={Link} className="items-stretch gap-4 p-2 sm:p-4" href={`/products/${id}`}>
+			<CardBody as={Link} className="items-stretch gap-4 p-2 sm:p-4" href={`/products/${id}?color=${activeColor}`}>
 				<div className="relative overflow-hidden rounded-lg group">
 					<Image
 						alt={name}

--- a/lib/search/relevant-image.ts
+++ b/lib/search/relevant-image.ts
@@ -4,6 +4,12 @@ export type ImageAwareHit = {
   variantImagesByColor?: Record<string, string>;
 };
 
+export type ImageMatchResult = {
+  image?: string;
+  color?: string;
+  matchType?: 'exact' | 'partial' | 'fuzzy' | 'fallback';
+};
+
 function normalizeToken(value: string): string {
   return value.trim().toLowerCase().replaceAll('ё', 'е');
 }
@@ -11,74 +17,97 @@ function normalizeToken(value: string): string {
 function tokenizeQuery(query: string): string[] {
   return query
     .split(/[\s,.;:!?/\\|()[\]{}"'+_-]+/)
-    .map((token) => normalizeToken(token))
+    .map(normalizeToken)
     .filter((token) => token.length > 1);
 }
 
-export function pickRelevantImageForQuery(hit: ImageAwareHit, query: string): string | undefined {
-  const fallback =
+function getFallback(hit: ImageAwareHit): ImageMatchResult {
+  const image =
     hit.imageUrl ||
-    (Array.isArray(hit.galleryImages) && hit.galleryImages.length > 0
-      ? hit.galleryImages[0]
-      : undefined);
+    (hit.galleryImages?.length ? hit.galleryImages[0] : undefined);
 
-  if (!query || typeof query !== 'string' || !hit.variantImagesByColor) {
-    return fallback;
+  return {
+    image,
+    matchType: 'fallback',
+  };
+}
+
+export function pickRelevantImageForQuery(
+  hit: ImageAwareHit,
+  query: string
+): ImageMatchResult {
+  if (!query || !hit.variantImagesByColor) {
+    return getFallback(hit);
   }
 
   const tokens = tokenizeQuery(query);
-  if (tokens.length === 0) {
-    return fallback;
+  if (!tokens.length) {
+    return getFallback(hit);
   }
 
   const variants = Object.entries(hit.variantImagesByColor)
-    .map(([rawColor, image]) => ({ color: normalizeToken(rawColor), image }))
-    .filter((entry) => entry.color !== '' && typeof entry.image === 'string' && entry.image.trim() !== '');
+    .map(([rawColor, image]) => ({
+      raw: rawColor,
+      color: normalizeToken(rawColor),
+      image,
+    }))
+    .filter((v) => v.color && v.image);
 
-  if (variants.length === 0) {
-    return fallback;
+  if (!variants.length) {
+    return getFallback(hit);
   }
 
-  for (const token of tokens) {
-    const exact = variants.find((entry) => entry.color === token);
-    if (exact) {
-      return exact.image;
+  // unified matcher
+  const findMatch = (
+    predicate: (token: string, color: string) => boolean
+  ): { token: string; variant: typeof variants[number] } | undefined => {
+    for (const token of tokens) {
+      const variant = variants.find((v) => predicate(token, v.color));
+      if (variant) return { token, variant };
     }
+  };
+
+  // 1. exact
+  const exact = findMatch((t, c) => c === t);
+  if (exact) {
+    return {
+      image: exact.variant.image,
+      color: exact.variant.raw,
+      matchType: 'exact',
+    };
   }
 
-  for (const token of tokens) {
-    const partial = variants.find(
-      (entry) => entry.color.includes(token) || token.includes(entry.color)
-    );
-    if (partial) {
-      return partial.image;
+  // 2. partial
+  const partial = findMatch((t, c) => c.includes(t) || t.includes(c));
+  if (partial) {
+    return {
+      image: partial.variant.image,
+      color: partial.variant.raw,
+      matchType: 'partial',
+    };
+  }
+
+  // 3. fuzzy (RU-friendly light stem)
+  const fuzzy = findMatch((t, c) => {
+    const minLen = Math.min(t.length, c.length);
+    const checkLen = Math.max(Math.floor(minLen * 0.7), minLen - 2);
+
+    if (c.slice(0, checkLen) === t.slice(0, checkLen)) return true;
+
+    if (minLen <= 5) {
+      return c.includes(t) || t.includes(c);
     }
+
+    return false;
+  });
+
+  if (fuzzy) {
+    return {
+      image: fuzzy.variant.image,
+      color: fuzzy.variant.raw,
+      matchType: 'fuzzy',
+    };
   }
 
-  // Additional fuzzy matching for cases like "серая" <-> "серый"
-  for (const token of tokens) {
-    const fuzzy = variants.find((entry) => {
-      // Check if token and color share a common root
-      const minLength = Math.min(entry.color.length, token.length);
-      const checkLength = Math.max(Math.floor(minLength * 0.7), minLength - 2);
-
-      // Compare beginnings of words
-      if (entry.color.substring(0, checkLength) === token.substring(0, checkLength)) {
-        return true;
-      }
-
-      // For short words, check if one contains the other
-      if (minLength <= 5) {
-        return entry.color.includes(token) || token.includes(entry.color);
-      }
-
-      return false;
-    });
-
-    if (fuzzy) {
-      return fuzzy.image;
-    }
-  }
-
-  return fallback;
+  return getFallback(hit);
 }

--- a/sanity/lib/product/searchProductsByAlgolia.ts
+++ b/sanity/lib/product/searchProductsByAlgolia.ts
@@ -49,8 +49,9 @@ const hasAlgoliaSearchConfig = () =>
   Boolean(process.env.NEXT_PUBLIC_ALGOLIA_APP_ID && process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_KEY);
 
 const mapAlgoliaHitToProduct = (hit: AlgoliaProductHit, searchQuery: string): ProductData => {
-  const relevantImage = pickRelevantImageForQuery(hit, searchQuery);
-  const image = typeof relevantImage === 'string' && relevantImage.trim() !== '' ? relevantImage : DEFAULT_IMAGE;
+  const relevant = pickRelevantImageForQuery(hit, searchQuery);
+  const image = typeof relevant.image === 'string' && relevant.image.trim() !== '' ? relevant.image : DEFAULT_IMAGE;
+  const color = typeof relevant.color === 'string' && relevant.color.trim() !== '' ? relevant.color : '';
   const id = String(hit.id ?? hit.objectID ?? '');
   const price =
     typeof hit.price === 'number'
@@ -71,6 +72,7 @@ const mapAlgoliaHitToProduct = (hit: AlgoliaProductHit, searchQuery: string): Pr
     name: hit.name ?? '',
     price,
     image,
+    activeColor: color,
     images: hit.galleryImages ?? [],
     images_urls: image,
     description: hit.description ?? '',


### PR DESCRIPTION
- Add `activeColor` field to ProductData to track color matched by search
- Enhance `pickRelevantImageForQuery` to return matched color alongside image
- Update product links to include selected color in URL query parameter
- Sync product detail color selection with URL state using `setSelectedColorURL`
- Ensure product page reads color from URL and uses it as initial selection