### PR TITLE
fix: bypass Next.js image optimization for problematic hosts

### DIFF
--- a/components/shared/product/ProductCarousel.tsx
+++ b/components/shared/product/ProductCarousel.tsx
@@ -15,6 +15,7 @@ import clsx from 'clsx';
 
 import {useProductStore} from '@/store/product';
 import Loader from '@/components/ui/Loader';
+import { shouldBypassNextImageOptimization } from '@/lib/image-utils';
 
 import styles from './product.module.css';
 import {getVariantImages} from './lib';
@@ -56,6 +57,7 @@ export const ProductCarousel = ({items, className}: ProductCarouselProps) => {
 									quality={60}
 									radius="sm"
 									src={item ? item : '/images/product-no-image.jpg'}
+									unoptimized={shouldBypassNextImageOptimization(item)}
 									width={500}
 								/>
 							</picture>
@@ -95,6 +97,7 @@ export const ProductCarousel = ({items, className}: ProductCarouselProps) => {
 									height={104}
 									radius="sm"
 									src={item ? item : '/images/product-no-image.jpg'}
+									unoptimized={shouldBypassNextImageOptimization(item)}
 									width={104}
 								/>
 							</picture>

--- a/components/shared/product/ProductColors.tsx
+++ b/components/shared/product/ProductColors.tsx
@@ -7,6 +7,7 @@ import { Button } from '@heroui/button';
 import { ChevronDownIcon } from 'lucide-react';
 
 import Loader from '@/components/ui/Loader';
+import { shouldBypassNextImageOptimization } from '@/lib/image-utils';
 
 import { ColorItemProps } from './product.types';
 import { filterItemsByColor } from './lib';
@@ -24,6 +25,7 @@ const ColorListItem = ({ item }: { item: ColorItemProps }) => (
             radius='sm'
             src={item.cover || '/images/product-no-image.jpg'}
             title={item.color}
+            unoptimized={shouldBypassNextImageOptimization(item.cover)}
             width={36}
         />
     </li>

--- a/components/shared/product/ui/ProductCard.tsx
+++ b/components/shared/product/ui/ProductCard.tsx
@@ -1,12 +1,15 @@
 // components/ProductCard.tsx
 import Image from 'next/image';
 import Link from 'next/link';
+import { shouldBypassNextImageOptimization } from '@/lib/image-utils';
 
 export default function ProductCard({ product }: { product: any }) {
+	const imageSrc = `${product.image || '/images/product-no-image.jpg'}`;
+
     return (
 		<Link className="border rounded p-4 shadow hover:shadow-lg transition" href={`/products/${product.id}`}>
 
-			<Image alt={product.title || 'Product Image'} className="w-full h-40 object-cover" height={500} src={`${product.image || '/images/product-no-image.jpg'}`} width={500} />
+			<Image alt={product.title || 'Product Image'} className="w-full h-40 object-cover" height={500} src={imageSrc} unoptimized={shouldBypassNextImageOptimization(imageSrc)} width={500} />
 			<h3 className="mt-2 font-semibold">{product.name}</h3>
 			<p className="text-gray-600">${product.price}</p>
 		</Link>

--- a/components/shared/product/ui/ProductThumb.tsx
+++ b/components/shared/product/ui/ProductThumb.tsx
@@ -10,6 +10,7 @@ import { ProductData } from '@/components/shared/product/product.types';
 import { getTotalStock, getProductImageByColor } from '@/components/shared/product/lib';
 import { CURRENCIES_SYMBOLS } from '@/lib/products/companies';
 import { FavoriteButton } from '@/components/shared/favorites/FavoriteButton';
+import { shouldBypassNextImageOptimization } from '@/lib/image-utils';
 
 import { ProductSizes } from '../ProductSizes';
 import { ProductColors } from '../ProductColors';
@@ -50,6 +51,7 @@ const ProductThumb: FC<ProductThumbProps> = ({ item, ...props }): JSX.Element =>
 						quality={50}
 						sizes='100vw'
 						src={image}
+						unoptimized={shouldBypassNextImageOptimization(image)}
 						width={220}
 					/>
 				</div>

--- a/lib/image-utils.ts
+++ b/lib/image-utils.ts
@@ -1,5 +1,7 @@
 import { urlFor } from "@/sanity/lib/image";
 
+const BYPASS_NEXT_IMAGE_OPTIMIZER_HOSTS = new Set(["markli.by", "www.markli.by"]);
+
 /**
  * Generate a CDN-optimized image URL for Algolia search results
  * @param image - Sanity image object
@@ -20,5 +22,22 @@ export function generateImageUrlForAlgolia(image: any): string | undefined {
   } catch (error) {
     console.warn("Failed to generate image URL for Algolia:", error);
     return undefined;
+  }
+}
+
+/**
+ * Some upstream image hosts frequently timeout when proxied through `/_next/image`.
+ * For these hosts, render the original URL directly via `unoptimized`.
+ */
+export function shouldBypassNextImageOptimization(src?: string | null): boolean {
+  if (!src || src.startsWith("/")) return false;
+
+  try {
+    const url = new URL(src);
+    const hostname = url.hostname.toLowerCase();
+
+    return BYPASS_NEXT_IMAGE_OPTIMIZER_HOSTS.has(hostname);
+  } catch {
+    return false;
   }
 }


### PR DESCRIPTION
Add a utility function to detect specific upstream image hosts that frequently timeout when proxied through Next.js image optimization. When such hosts are detected, the `unoptimized` prop is set on Next/Image components to load the original image URL directly, preventing timeouts.

This change is applied to ProductThumb, ProductCard, ProductColors, and ProductCarousel components to ensure reliable image loading across the product UI.