### PR TITLE
feat: add staging environment support and block search indexing

### DIFF
--- a/.env.staging.example
+++ b/.env.staging.example
@@ -1,0 +1,39 @@
+# Staging environment variables (Netlify `main` branch deployment)
+# Copy these keys into Netlify Site Settings -> Environment variables
+# Do not commit real secret values.
+
+# App
+NEXT_PUBLIC_APP_ENV=staging
+NEXT_PUBLIC_SERVER_URL=https://staging.example.com
+NEXT_PUBLIC_LOCALE=ru-BY
+NEXT_PUBLIC_COUNTRY=BY
+
+# Database / backend secrets
+DATABASE_URI=
+CRON_SECRET=
+PAYLOAD_SECRET=
+
+# Telegram
+TELEGRAM_BOT_TOKEN=
+TELEGRAM_CHAT_ID=
+TELEGRAM_PVD_CHAT_ID=
+
+# Sanity
+NEXT_PUBLIC_SANITY_PROJECT_ID=
+NEXT_PUBLIC_SANITY_DATASET=staging
+NEXT_PUBLIC_SANITY_TOKEN=
+
+# Algolia
+NEXT_PUBLIC_ALGOLIA_APP_ID=
+NEXT_PUBLIC_ALGOLIA_SEARCH_KEY=
+ALGOLIA_ADMIN_KEY=
+
+# Analytics
+NEXT_PUBLIC_GTM_ID=
+
+# Google Service
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URI=${NEXT_PUBLIC_SERVER_URL}
+GOOGLE_REFRESH_TOKEN=
+GOOGLE_ACCESS_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ yarn-error.log*
 
 # env files
 .env
+.env.staging
+.env.production
 
 # local env files
 .env*.local

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,6 +16,8 @@ import { Providers } from './(app)/providers';
 const SITE_URL = process.env.NEXT_PUBLIC_SERVER_URL || 'https://artmarketprint.by';
 const SITE_LOCALE = process.env.NEXT_PUBLIC_LOCALE || 'ru_BY';
 const GTM_ID = process.env.NEXT_PUBLIC_GTM_ID || '';
+const APP_ENV = process.env.NEXT_PUBLIC_APP_ENV || 'production';
+const IS_STAGING = APP_ENV === 'staging';
 
 export const metadata: Metadata = {
 	metadataBase: new URL(SITE_URL),
@@ -58,6 +60,20 @@ export const metadata: Metadata = {
 			'algolia-site-verification': '04FE8CF3E01395C5',
 		},
 	},
+	robots: IS_STAGING
+		? {
+				index: false,
+				follow: false,
+				googleBot: {
+					index: false,
+					follow: false,
+					noimageindex: true,
+				},
+			}
+		: {
+				index: true,
+				follow: true,
+			},
 };
 
 export const viewport: Viewport = {

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,6 +1,20 @@
 import type {MetadataRoute} from 'next';
 
 export default function robots(): MetadataRoute.Robots {
+	const APP_ENV = process.env.NEXT_PUBLIC_APP_ENV || 'production';
+	const IS_STAGING = APP_ENV === 'staging';
+
+	if (IS_STAGING) {
+		return {
+			rules: [
+				{
+					userAgent: '*',
+					disallow: '/',
+				},
+			],
+		};
+	}
+
 	return {
 		rules: [
 			{

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -5,6 +5,13 @@ import {client} from '@/sanity/client';
 const BASE_URL = process.env.NEXT_PUBLIC_SERVER_URL;
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+	const APP_ENV = process.env.NEXT_PUBLIC_APP_ENV || 'production';
+	const IS_STAGING = APP_ENV === 'staging';
+
+	if (IS_STAGING) {
+		return [];
+	}
+
 	const staticPages: MetadataRoute.Sitemap = [
 		{
 			url: `${BASE_URL}/`,


### PR DESCRIPTION
- Add .env.staging and .env.production to gitignore
- Create .env.staging.example with staging configuration
- Update robots.ts and sitemap.ts to return no-index for staging
- Add robots metadata in layout to prevent staging indexing
- Use NEXT_PUBLIC_APP_ENV to determine environment